### PR TITLE
Replace Poison with Jason

### DIFF
--- a/lib/avro_ex/schema.ex
+++ b/lib/avro_ex/schema.ex
@@ -45,7 +45,7 @@ defmodule AvroEx.Schema do
 
   @spec parse(json_schema, Context.t()) :: {:ok, t} | {:error, term}
   def parse(json_schema, %Context{} = context \\ %Context{}) do
-    with {:ok, schema} <- Poison.decode(json_schema),
+    with {:ok, schema} <- Jason.decode(json_schema),
          {:ok, schema} <- cast(schema),
          {:ok, schema} <- namespace(schema),
          {:ok, context} <- expand(schema, context) do

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule AvroEx.Mixfile do
 
   defp deps do
     [
-      {:poison, "~> 3.1.0"},
+      {:jason, "~> 1.1"},
       {:ex_doc, "~> 0.18.0", only: :dev, runtime: false},
       {:ecto, "~> 3.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -3,6 +3,7 @@
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "3.0.7", "44dda84ac6b17bbbdeb8ac5dfef08b7da253b37a453c34ab1a98de7f7e5fec7f", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
 }

--- a/test/record_test.exs
+++ b/test/record_test.exs
@@ -159,12 +159,12 @@ defmodule AvroEx.Schema.Record.Test do
       }
 
       state = %{
-        both: both |> Poison.encode!(),
-        no_namespace: no_namespace |> Poison.encode!(),
-        prov_nprov: prov_nprov |> Poison.encode!(),
-        nprov_nprov: nprov_nprov |> Poison.encode!(),
-        nprov_prov: nprov_prov |> Poison.encode!(),
-        prov_prov: prov_prov |> Poison.encode!()
+        both: both |> Jason.encode!(),
+        no_namespace: no_namespace |> Jason.encode!(),
+        prov_nprov: prov_nprov |> Jason.encode!(),
+        nprov_nprov: nprov_nprov |> Jason.encode!(),
+        nprov_prov: nprov_prov |> Jason.encode!(),
+        prov_prov: prov_prov |> Jason.encode!()
       }
 
       {:ok, state}

--- a/test/record_test.exs
+++ b/test/record_test.exs
@@ -159,12 +159,12 @@ defmodule AvroEx.Schema.Record.Test do
       }
 
       state = %{
-        both: both |> Jason.encode!(),
-        no_namespace: no_namespace |> Jason.encode!(),
-        prov_nprov: prov_nprov |> Jason.encode!(),
-        nprov_nprov: nprov_nprov |> Jason.encode!(),
-        nprov_prov: nprov_prov |> Jason.encode!(),
-        prov_prov: prov_prov |> Jason.encode!()
+        both: Jason.encode!(both),
+        no_namespace: Jason.encode!(no_namespace),
+        prov_nprov: Jason.encode!(prov_nprov),
+        nprov_nprov: Jason.encode!(nprov_nprov),
+        nprov_prov: Jason.encode!(nprov_prov),
+        prov_prov: Jason.encode!(prov_prov)
       }
 
       {:ok, state}

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -113,9 +113,9 @@ defmodule AvroEx.Schema.Test do
 
   def json_add_property(str, property, value) when is_binary(str) do
     str
-    |> Poison.decode!()
+    |> Jason.decode!()
     |> json_add_property(property, value)
-    |> Poison.encode!()
+    |> Jason.encode!()
   end
 
   def json_add_property(json, property, value) when is_map(json) and is_atom(property) do


### PR DESCRIPTION
Jason is faster than poison and is the current consensus choice for non-NIF json encoding.