### PR TITLE
Fix integer and long encoding/decoding issues

### DIFF
--- a/lib/avro_ex/decode.ex
+++ b/lib/avro_ex/decode.ex
@@ -234,12 +234,14 @@ defmodule AvroEx.Decode do
 
   @spec variable_integer_decode(bitstring(), integer(), integer(), integer()) :: {integer(), bitstring()}
   def variable_integer_decode(<<tag::1, value::7, tail::bitstring>>, acc, acc_bits, max_bits) do
-    true = (acc_bits < max_bits)  # assertion
+    # assertion
+    true = acc_bits < max_bits
+
     new_acc =
       value
       |> Bitwise.bsl(acc_bits)
       |> Bitwise.bor(acc)
-    
+
     case tag do
       0 -> {new_acc, tail}
       1 -> variable_integer_decode(tail, new_acc, acc_bits + 7, max_bits)

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -219,7 +219,7 @@ defmodule AvroEx.Encode do
     value =
       long
       |> Bitwise.bsl(1)
-      |> Bitwise.bxor(Bitwise.bsr(long, 61))
+      |> Bitwise.bxor(Bitwise.bsr(long, 63))
 
     <<value::64>>
   end

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -207,143 +207,22 @@ defmodule AvroEx.Encode do
 
   @spec zigzag_encode(Primitive.t(), integer) :: binary
   def zigzag_encode(%Primitive{type: :integer}, int) when is_integer(int) do
-    value =
-      int
-      |> Bitwise.bsl(1)
-      |> Bitwise.bxor(Bitwise.bsr(int, 31))
-
-    <<value::32>>
+    int
+    |> Bitwise.bsl(1)
+    |> Bitwise.bxor(Bitwise.bsr(int, 31))
   end
 
   def zigzag_encode(%Primitive{type: :long}, long) when is_integer(long) do
-    value =
-      long
-      |> Bitwise.bsl(1)
-      |> Bitwise.bxor(Bitwise.bsr(long, 63))
-
-    <<value::64>>
+    long
+    |> Bitwise.bsl(1)
+    |> Bitwise.bxor(Bitwise.bsr(long, 63))
   end
 
-  @spec variable_integer_encode(<<_::32, _::_*32>>) :: <<_::8, _::_*8>>
-  def variable_integer_encode(<<0::32>>), do: <<0::8>>
-  def variable_integer_encode(<<0::25, byte::7>>), do: <<byte::8>>
-
-  def variable_integer_encode(<<0::18, byte1::7, byte2::7>>) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte2, byte1>>
+  @spec variable_integer_encode(integer()) :: <<_::8, _::_*8>>
+  def variable_integer_encode(value) when value <= 127, do: <<value>>
+  def variable_integer_encode(value) do
+    <<128 + Bitwise.band(value, 127)>> <> variable_integer_encode(Bitwise.bsr(value, 7))
   end
-
-  def variable_integer_encode(<<0::11, byte1::7, byte2::7, byte3::7>>) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte3::8>> = wrap(byte3)
-    <<byte3, byte2, byte1>>
-  end
-
-  def variable_integer_encode(<<0::4, byte1::7, byte2::7, byte3::7, byte4::7>>) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte3::8>> = wrap(byte3)
-    <<byte4::8>> = wrap(byte4)
-    <<byte4, byte3, byte2, byte1>>
-  end
-
-  def variable_integer_encode(<<byte1::4, byte2::7, byte3::7, byte4::7, byte5::7>>) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte3::8>> = wrap(byte3)
-    <<byte4::8>> = wrap(byte4)
-    <<byte5::8>> = wrap(byte5)
-    <<byte5, byte4, byte3, byte2, byte1>>
-  end
-
-  def variable_integer_encode(<<0::64>>), do: <<0::8>>
-  def variable_integer_encode(<<0::57, byte1::7>>), do: <<byte1::8>>
-
-  def variable_integer_encode(<<0::50, byte1::7, byte2::7>>) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte2, byte1>>
-  end
-
-  def variable_integer_encode(<<0::43, byte1::7, byte2::7, byte3::7>>) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte3::8>> = wrap(byte3)
-    <<byte3, byte2, byte1>>
-  end
-
-  def variable_integer_encode(<<0::36, byte1::7, byte2::7, byte3::7, byte4::7>>) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte3::8>> = wrap(byte3)
-    <<byte4::8>> = wrap(byte4)
-    <<byte4, byte3, byte2, byte1>>
-  end
-
-  def variable_integer_encode(<<0::29, byte1::7, byte2::7, byte3::7, byte4::7, byte5::7>>) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte3::8>> = wrap(byte3)
-    <<byte4::8>> = wrap(byte4)
-    <<byte5::8>> = wrap(byte5)
-    <<byte5, byte4, byte3, byte2, byte1>>
-  end
-
-  def variable_integer_encode(<<0::22, byte1::7, byte2::7, byte3::7, byte4::7, byte5::7, byte6::7>>) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte3::8>> = wrap(byte3)
-    <<byte4::8>> = wrap(byte4)
-    <<byte5::8>> = wrap(byte5)
-    <<byte6::8>> = wrap(byte6)
-    <<byte6, byte5, byte4, byte3, byte2, byte1>>
-  end
-
-  def variable_integer_encode(<<0::15, byte1::7, byte2::7, byte3::7, byte4::7, byte5::7, byte6::7, byte7::7>>) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte3::8>> = wrap(byte3)
-    <<byte4::8>> = wrap(byte4)
-    <<byte5::8>> = wrap(byte5)
-    <<byte6::8>> = wrap(byte6)
-    <<byte7::8>> = wrap(byte7)
-    <<byte7, byte6, byte5, byte4, byte3, byte2, byte1>>
-  end
-
-  def variable_integer_encode(<<0::8, byte1::7, byte2::7, byte3::7, byte4::7, byte5::7, byte6::7, byte7::7, byte8::7>>) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte3::8>> = wrap(byte3)
-    <<byte4::8>> = wrap(byte4)
-    <<byte5::8>> = wrap(byte5)
-    <<byte6::8>> = wrap(byte6)
-    <<byte7::8>> = wrap(byte7)
-    <<byte8::8>> = wrap(byte8)
-    <<byte8, byte7, byte6, byte5, byte4, byte3, byte2, byte1>>
-  end
-
-  def variable_integer_encode(
-        <<0::1, byte1::7, byte2::7, byte3::7, byte4::7, byte5::7, byte6::7, byte7::7, byte8::7, byte9::7>>
-      ) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte3::8>> = wrap(byte3)
-    <<byte4::8>> = wrap(byte4)
-    <<byte5::8>> = wrap(byte5)
-    <<byte6::8>> = wrap(byte6)
-    <<byte7::8>> = wrap(byte7)
-    <<byte8::8>> = wrap(byte8)
-    <<byte9::8>> = wrap(byte9)
-    <<byte9, byte8, byte7, byte6, byte5, byte4, byte3, byte2, byte1>>
-  end
-
-  def variable_integer_encode(
-        <<byte1::1, byte2::7, byte3::7, byte4::7, byte5::7, byte6::7, byte7::7, byte8::7, byte9::7, byte10::7>>
-      ) do
-    <<byte2::8>> = wrap(byte2)
-    <<byte3::8>> = wrap(byte3)
-    <<byte4::8>> = wrap(byte4)
-    <<byte5::8>> = wrap(byte5)
-    <<byte6::8>> = wrap(byte6)
-    <<byte7::8>> = wrap(byte7)
-    <<byte8::8>> = wrap(byte8)
-    <<byte9::8>> = wrap(byte9)
-    <<byte10::8>> = wrap(byte10)
-    <<byte10, byte9, byte8, byte7, byte6, byte5, byte4, byte3, byte2, byte1>>
-  end
-
-  @spec wrap(integer()) :: <<_::8>>
-  def wrap(byte), do: <<1::1, byte::7>>
 
   defp encode_integer(int, schema) do
     schema

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -220,6 +220,7 @@ defmodule AvroEx.Encode do
 
   @spec variable_integer_encode(integer()) :: <<_::8, _::_*8>>
   def variable_integer_encode(value) when value <= 127, do: <<value>>
+
   def variable_integer_encode(value) do
     <<128 + Bitwise.band(value, 127)>> <> variable_integer_encode(Bitwise.bsr(value, 7))
   end

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -36,7 +36,6 @@ defmodule AvroEx.Decode.Test do
       assert {:ok, -5_000_000} = @test_module.decode(schema, small)
       assert {:ok, -2_147_483_648} = @test_module.decode(schema, min_int32)
       assert {:ok, 2_147_483_647} = @test_module.decode(schema, max_int32)
-
     end
 
     test "long" do

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -26,12 +26,17 @@ defmodule AvroEx.Decode.Test do
       {:ok, ten} = AvroEx.encode(schema, 10)
       {:ok, big} = AvroEx.encode(schema, 5_000_000)
       {:ok, small} = AvroEx.encode(schema, -5_000_000)
+      {:ok, min_int32} = AvroEx.encode(schema, -2_147_483_648)
+      {:ok, max_int32} = AvroEx.encode(schema, 2_147_483_647)
 
       assert {:ok, 0} = @test_module.decode(schema, zero)
       assert {:ok, -10} = @test_module.decode(schema, neg_ten)
       assert {:ok, 10} = @test_module.decode(schema, ten)
       assert {:ok, 5_000_000} = @test_module.decode(schema, big)
       assert {:ok, -5_000_000} = @test_module.decode(schema, small)
+      assert {:ok, -2_147_483_648} = @test_module.decode(schema, min_int32)
+      assert {:ok, 2_147_483_647} = @test_module.decode(schema, max_int32)
+
     end
 
     test "long" do
@@ -41,12 +46,16 @@ defmodule AvroEx.Decode.Test do
       {:ok, ten} = AvroEx.encode(schema, 10)
       {:ok, big} = AvroEx.encode(schema, 2_147_483_647)
       {:ok, small} = AvroEx.encode(schema, -2_147_483_647)
+      {:ok, min_int64} = AvroEx.encode(schema, -9_223_372_036_854_775_808)
+      {:ok, max_int64} = AvroEx.encode(schema, 9_223_372_036_854_775_807)
 
       assert {:ok, 0} = @test_module.decode(schema, zero)
       assert {:ok, -10} = @test_module.decode(schema, neg_ten)
       assert {:ok, 10} = @test_module.decode(schema, ten)
       assert {:ok, 2_147_483_647} = @test_module.decode(schema, big)
       assert {:ok, -2_147_483_647} = @test_module.decode(schema, small)
+      assert {:ok, -9_223_372_036_854_775_808} = @test_module.decode(schema, min_int64)
+      assert {:ok, 9_223_372_036_854_775_807} = @test_module.decode(schema, max_int64)
     end
 
     test "float" do

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -57,10 +57,7 @@ defmodule AvroEx.Encode.Test do
   end
 
   describe "variable_integer_encode (int)" do
-    Macros.assert_result(
-      @test_module,
-      :variable_integer_encode,
-      [0], <<0>>)
+    Macros.assert_result(@test_module, :variable_integer_encode, [0], <<0>>)
 
     Macros.assert_result(
       @test_module,

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -57,79 +57,87 @@ defmodule AvroEx.Encode.Test do
   end
 
   describe "variable_integer_encode (int)" do
-    Macros.assert_result(@test_module, :variable_integer_encode, [<<0::size(32)>>], <<0>>)
+    Macros.assert_result(
+      @test_module,
+      :variable_integer_encode,
+      [0], <<0>>)
 
     Macros.assert_result(
       @test_module,
       :variable_integer_encode,
-      [<<1::size(32)>>],
+      [1],
       <<1::size(8)>>
     )
 
     Macros.assert_result(
       @test_module,
       :variable_integer_encode,
-      [<<128::size(32)>>],
+      [128],
       <<32_769::size(16)>>
     )
 
     Macros.assert_result(
       @test_module,
       :variable_integer_encode,
-      [<<16_383::size(32)>>],
+      [16_383],
       <<65_407::size(16)>>
     )
 
     Macros.assert_result(
       @test_module,
       :variable_integer_encode,
-      [<<16_384::size(32)>>],
+      [16_384],
       <<8_421_377::size(24)>>
     )
 
     Macros.assert_result(
       @test_module,
       :variable_integer_encode,
-      [<<4_294_967_041::size(32)>>],
+      [4_294_967_041],
       <<129, 254, 255, 255, 15>>
     )
   end
 
   describe "variable_integer_encode (long)" do
-    Macros.assert_result(@test_module, :variable_integer_encode, [<<0::size(64)>>], <<0>>)
+    Macros.assert_result(
+      @test_module,
+      :variable_integer_encode,
+      [0],
+      <<0>>
+    )
 
     Macros.assert_result(
       @test_module,
       :variable_integer_encode,
-      [<<1::size(64)>>],
+      [1],
       <<1::size(8)>>
     )
 
     Macros.assert_result(
       @test_module,
       :variable_integer_encode,
-      [<<128::size(64)>>],
+      [128],
       <<32_769::size(16)>>
     )
 
     Macros.assert_result(
       @test_module,
       :variable_integer_encode,
-      [<<16_383::size(64)>>],
+      [16_383],
       <<65_407::size(16)>>
     )
 
     Macros.assert_result(
       @test_module,
       :variable_integer_encode,
-      [<<16_384::size(64)>>],
+      [16_384],
       <<8_421_377::size(24)>>
     )
 
     Macros.assert_result(
       @test_module,
       :variable_integer_encode,
-      [<<4_294_967_041::size(64)>>],
+      [4_294_967_041],
       <<129, 254, 255, 255, 15>>
     )
   end

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -56,52 +56,8 @@ defmodule AvroEx.Encode.Test do
     end
   end
 
-  describe "variable_integer_encode (int)" do
+  describe "variable_integer_encode" do
     Macros.assert_result(@test_module, :variable_integer_encode, [0], <<0>>)
-
-    Macros.assert_result(
-      @test_module,
-      :variable_integer_encode,
-      [1],
-      <<1::size(8)>>
-    )
-
-    Macros.assert_result(
-      @test_module,
-      :variable_integer_encode,
-      [128],
-      <<32_769::size(16)>>
-    )
-
-    Macros.assert_result(
-      @test_module,
-      :variable_integer_encode,
-      [16_383],
-      <<65_407::size(16)>>
-    )
-
-    Macros.assert_result(
-      @test_module,
-      :variable_integer_encode,
-      [16_384],
-      <<8_421_377::size(24)>>
-    )
-
-    Macros.assert_result(
-      @test_module,
-      :variable_integer_encode,
-      [4_294_967_041],
-      <<129, 254, 255, 255, 15>>
-    )
-  end
-
-  describe "variable_integer_encode (long)" do
-    Macros.assert_result(
-      @test_module,
-      :variable_integer_encode,
-      [0],
-      <<0>>
-    )
 
     Macros.assert_result(
       @test_module,


### PR DESCRIPTION
This PR fixes various issues with `integer` and `long` encoding and decoding.

* `long` encoding was applying a 61 bit right shift whereas a 63 bit shift is required.
* `integer` decoding was not working with numbers above 134_217_727. A similar limit different than max `int64` was also present on `long` decoding
* refactor the code based on `erlavro` implementation for encoding/decoding integers/longs