### PR TITLE
Add type for AvroEx.Schema.Record.Field to fix compilation error

### DIFF
--- a/lib/avro_ex/schema/record/field.ex
+++ b/lib/avro_ex/schema/record/field.ex
@@ -6,6 +6,8 @@ defmodule AvroEx.Schema.Record.Field do
   alias AvroEx.{Schema, Term}
   alias AvroEx.Schema.Context
 
+  @type t() :: %__MODULE__{}
+
   embedded_schema do
     field(:name, :string)
     field(:doc, :string)


### PR DESCRIPTION
Small PR to fix a compilation error (see linked issue).

Fixes https://github.com/beam-community/avro_ex/issues/32