### PR TITLE
Support encoding DateTime and Time to logical types in Union

### DIFF
--- a/lib/avro_ex/schema.ex
+++ b/lib/avro_ex/schema.ex
@@ -111,6 +111,12 @@ defmodule AvroEx.Schema do
   def encodable?(%Primitive{type: :bytes}, _, bytes) when is_binary(bytes), do: true
   def encodable?(%Primitive{type: :string}, _, str) when is_binary(str), do: String.valid?(str)
 
+  def encodable?(%Primitive{type: :long, metadata: %{"logicalType" => "timestamp-nanos"}}, _, %DateTime{}), do: true
+  def encodable?(%Primitive{type: :long, metadata: %{"logicalType" => "timestamp-micros"}}, _, %DateTime{}), do: true
+  def encodable?(%Primitive{type: :long, metadata: %{"logicalType" => "timestamp-millis"}}, _, %DateTime{}), do: true
+  def encodable?(%Primitive{type: :long, metadata: %{"logicalType" => "time-micros"}}, _, %Time{}), do: true
+  def encodable?(%Primitive{type: :int, metadata: %{"logicalType" => "time-millis"}}, _, %Time{}), do: true
+
   def encodable?(%Record{} = record, %Context{} = context, data) when is_map(data),
     do: Record.match?(record, context, data)
 

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -113,6 +113,28 @@ defmodule AvroEx.Decode.Test do
       assert {:ok, 25} = @test_module.decode(schema, encoded_int)
     end
 
+    test "union with DateTime" do
+      {:ok, schema} = AvroEx.parse_schema(~S(["null", {"type": "long", "logicalType":"timestamp-micros"}]))
+      datetime = DateTime.utc_now()
+
+      {:ok, encoded_null} = AvroEx.encode(schema, nil)
+      {:ok, encoded_datetime} = AvroEx.encode(schema, datetime)
+
+      assert {:ok, nil} = @test_module.decode(schema, encoded_null)
+      assert {:ok, ^datetime} = @test_module.decode(schema, encoded_datetime)
+    end
+
+    test "union with Time" do
+      {:ok, schema} = AvroEx.parse_schema(~S(["null", {"type": "long", "logicalType":"time-micros"}]))
+      time = Time.utc_now()
+
+      {:ok, encoded_null} = AvroEx.encode(schema, nil)
+      {:ok, encoded_time} = AvroEx.encode(schema, time)
+
+      assert {:ok, nil} = @test_module.decode(schema, encoded_null)
+      assert {:ok, ^time} = @test_module.decode(schema, encoded_time)
+    end
+
     test "array" do
       {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": ["null", "int"]}))
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -190,6 +190,20 @@ defmodule AvroEx.Encode.Test do
       assert encoded_union == index <> encoded_int
     end
 
+    test "works as expected with logical types" do
+      datetime_json = ~S({"type": "long", "logicalType":"timestamp-millis"})
+      datetime_value = ~U[2020-09-17 12:56:50.438Z]
+
+      {:ok, schema} = AvroEx.parse_schema(~s(["null", #{datetime_json}]))
+      {:ok, datetime_schema} = AvroEx.parse_schema(datetime_json)
+
+      {:ok, index} = @test_module.encode(datetime_schema, 1)
+      {:ok, encoded_datetime} = @test_module.encode(datetime_schema, datetime_value)
+      {:ok, encoded_union} = @test_module.encode(schema, datetime_value)
+
+      assert encoded_union == index <> encoded_datetime
+    end
+
     test "works as expected with records" do
       record_json = ~S"""
         {

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -459,6 +459,18 @@ defmodule AvroEx.Schema.Test do
       refute @test_module.encodable?(schema, true)
       refute @test_module.encodable?(schema, %{"Hello" => "world"})
     end
+
+    test "works with logical types" do
+      {:ok, schema} = @test_module.parse(~S(["null", {"type": "long", "logicalType":"timestamp-millis"}]))
+
+      assert @test_module.encodable?(schema, nil)
+      assert @test_module.encodable?(schema, DateTime.utc_now())
+      assert @test_module.encodable?(schema, 1_525_658_987)
+
+      refute @test_module.encodable?(schema, 1.5)
+      refute @test_module.encodable?(schema, "AvroEx")
+      refute @test_module.encodable?(schema, Time.utc_now())
+    end
   end
 
   describe "encodable? (map)" do


### PR DESCRIPTION
It was possible to encode a DateTime to a `timestamp-<unit>` logical type and a Time to a `time-<unit>` logical type.
However, if the logical type was part of a Union, it would not work because it was not considered encodable.

Fixes #31