### PR TITLE
Fix record encoding exception for bad data

### DIFF
--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -101,7 +101,8 @@ defmodule AvroEx.Encode do
     encode_integer(integer, schema)
   end
 
-  def do_encode(%Primitive{type: :string} = primitive, %Context{} = context, atom) when is_atom(atom) do
+  def do_encode(%Primitive{type: :string} = primitive, %Context{} = context, atom)
+      when is_atom(atom) and not is_nil(atom) do
     do_encode(primitive, context, to_string(atom))
   end
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -54,6 +54,9 @@ defmodule AvroEx.Encode.Test do
 
       assert {:ok, <<14, 97, 98, 99, 100, 101, 102, 103>>} = @test_module.encode(schema, "abcdefg")
       assert {:ok, <<14, 97, 98, 99, 100, 101, 102, 103>>} = @test_module.encode(schema, :abcdefg)
+
+      assert {:error, :data_does_not_match_schema, nil, %AvroEx.Schema.Primitive{metadata: %{}, type: :string}} =
+               @test_module.encode(schema, nil)
     end
   end
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -185,6 +185,18 @@ defmodule AvroEx.Encode.Test do
       assert {:ok, <<0>>} = @test_module.encode(schema, %{})
       assert {:ok, <<2, 2, 49>>} = @test_module.encode(schema, %{"maybe_null" => "1"})
     end
+
+    test "returns an error if it doesn't match the schema" do
+      {:ok, schema} = AvroEx.parse_schema(~S({"type": "record", "name": "Record", "fields": [
+        {"type": "string", "name": "first"},
+        {"type": "string", "name": "last"}
+        ]}))
+
+      assert {:ok, "\bDave\nLucia"} = @test_module.encode(schema, %{"first" => "Dave", "last" => "Lucia"})
+
+      assert {:error, :data_does_not_match_schema, nil, %AvroEx.Schema.Primitive{metadata: %{}, type: :string}} =
+               @test_module.encode(schema, %{})
+    end
   end
 
   describe "encode (union)" do


### PR DESCRIPTION
Fixes encoding errors when you have a Record and pass it bad or missing data. 

```elixir
{:ok, schema} = AvroEx.parse_schema(~S({"type": "record", "name": "Record", "fields": [
  {"type": "string", "name": "first"},
  {"type": "string", "name": "last"}
  ]}))

AvroEx.encode(schema, %{})
```

Before:

```elixir
     ** (Protocol.UndefinedError) protocol String.Chars not implemented for {:error, :data_does_not_match_schema, nil, %AvroEx.Schema.Primitive{metadata: %{}, type: :string}} of type Tuple. This protocol is implemented for the following type(s): Atom, BitString, Date, DateTime, Decimal, Float, Integer, List, NaiveDateTime, Time, URI, Version, Version.Requirement
```

After:

```elixir
{:error, :data_does_not_match_schema, nil, %AvroEx.Schema.Primitive{metadata: %{}, type: :string}}
```