### PR TITLE
AvroEx.encodable? to account for atoms

### DIFF
--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -100,7 +100,7 @@ defmodule AvroEx.Encode do
   end
 
   defp do_encode(%Primitive{type: :string} = primitive, %Context{} = context, atom)
-       when is_atom(atom) and not is_nil(atom) do
+       when is_atom(atom) and not (is_nil(atom) or is_boolean(atom)) do
     do_encode(primitive, context, to_string(atom))
   end
 

--- a/lib/avro_ex/schema.ex
+++ b/lib/avro_ex/schema.ex
@@ -111,6 +111,14 @@ defmodule AvroEx.Schema do
   def encodable?(%Primitive{type: :bytes}, _, bytes) when is_binary(bytes), do: true
   def encodable?(%Primitive{type: :string}, _, str) when is_binary(str), do: String.valid?(str)
 
+  def encodable?(%Primitive{type: :string}, _, atom) when is_atom(atom) do
+    if is_nil(atom) or is_boolean(atom) do
+      false
+    else
+      atom |> to_string() |> String.valid?()
+    end
+  end
+
   def encodable?(%Primitive{type: :long, metadata: %{"logicalType" => "timestamp-nanos"}}, _, %DateTime{}), do: true
   def encodable?(%Primitive{type: :long, metadata: %{"logicalType" => "timestamp-micros"}}, _, %DateTime{}), do: true
   def encodable?(%Primitive{type: :long, metadata: %{"logicalType" => "timestamp-millis"}}, _, %DateTime{}), do: true
@@ -135,6 +143,10 @@ defmodule AvroEx.Schema do
 
   def encodable?(%Array{} = schema, %Context{} = context, data) when is_list(data) do
     Array.match?(schema, context, data)
+  end
+
+  def encodable?(%AvroEnum{} = schema, %Context{} = context, data) when is_atom(data) do
+    AvroEnum.match?(schema, context, to_string(data))
   end
 
   def encodable?(%AvroEnum{} = schema, %Context{} = context, data) when is_binary(data) do

--- a/lib/avro_ex/schema/record.ex
+++ b/lib/avro_ex/schema/record.ex
@@ -44,6 +44,12 @@ defmodule AvroEx.Schema.Record do
   def match?(%__MODULE__{fields: fields}, %Context{} = context, data)
       when is_map(data) and map_size(data) == length(fields) do
     Enum.all?(fields, fn %Field{name: name} = field ->
+      data =
+        Map.new(data, fn
+          {k, v} when is_binary(k) -> {k, v}
+          {k, v} when is_atom(k) -> {to_string(k), v}
+        end)
+
       Map.has_key?(data, name) and Schema.encodable?(field, context, data[name])
     end)
   end

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -57,6 +57,12 @@ defmodule AvroEx.Encode.Test do
 
       assert {:error, :data_does_not_match_schema, nil, %AvroEx.Schema.Primitive{metadata: %{}, type: :string}} =
                @test_module.encode(schema, nil)
+
+      assert {:error, :data_does_not_match_schema, true, %AvroEx.Schema.Primitive{metadata: %{}, type: :string}} =
+               @test_module.encode(schema, true)
+
+      assert {:error, :data_does_not_match_schema, false, %AvroEx.Schema.Primitive{metadata: %{}, type: :string}} =
+               @test_module.encode(schema, false)
     end
   end
 

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -306,6 +306,12 @@ defmodule AvroEx.Schema.Test do
       end
     end
 
+    test "accepts atoms as strings" do
+      {:ok, schema} = AvroEx.parse_schema(~S("string"))
+      assert @test_module.encodable?(schema, :dave)
+      refute @test_module.encodable?(schema, nil)
+    end
+
     test "does not accept non-utf8 strings as string" do
       {:ok, schema} = AvroEx.parse_schema(~S("string"))
       refute @test_module.encodable?(schema, <<128>>)
@@ -379,6 +385,10 @@ defmodule AvroEx.Schema.Test do
       refute @test_module.encodable?(schema, %{"first_name" => "Cody", "age" => "Cody"})
       refute @test_module.encodable?(schema, %{"first_name" => 30, "age" => 30})
       refute @test_module.encodable?(schema, %{"first_name" => "Cody", "ages" => 30})
+    end
+
+    test "records can have keys as atoms", %{schema: schema} do
+      assert @test_module.encodable?(schema, %{first_name: "Dave", age: 32})
     end
   end
 
@@ -504,6 +514,11 @@ defmodule AvroEx.Schema.Test do
       {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
       assert @test_module.encodable?(schema, %{})
     end
+
+    test "maps can have atom keys" do
+      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
+      assert @test_module.encodable?(schema, %{a: 1, b: 2})
+    end
   end
 
   describe "encodable? (array)" do
@@ -565,6 +580,13 @@ defmodule AvroEx.Schema.Test do
         AvroEx.parse_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
 
       refute @test_module.encodable?(schema, "kkjasdfkasdfj")
+    end
+
+    test "enums can have atoms" do
+      {:ok, schema} =
+        AvroEx.parse_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
+
+      assert @test_module.encodable?(schema, :heart)
     end
   end
 end


### PR DESCRIPTION
Also fixes a bug where `true` and `false` were encodable as strings