### PR TITLE
Improve errors/exceptions in AvroEx.encode/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+* `AvroEx.encode/2` now returns `{:error, AvroEx.EncodeError.t()}` in the case of an error
+
+### Added
+* `AvroEx.encode!/2` - identical to `encode/2`, but raises
+
 ## v1.2.0
 
 ### Fixed

--- a/lib/avro_ex.ex
+++ b/lib/avro_ex.ex
@@ -66,6 +66,7 @@ defmodule AvroEx do
   @doc """
   Same as `encode/2`, but returns the encoded value directly and raises on errors
   """
+  @spec encode!(Schema.t(), term()) :: encoded_avro()
   def encode!(schema, data) do
     case AvroEx.Encode.encode(schema, data) do
       {:ok, data} -> data

--- a/lib/avro_ex.ex
+++ b/lib/avro_ex.ex
@@ -58,9 +58,7 @@ defmodule AvroEx do
   Checks that the data is encodable before beginning encoding.
   """
   @spec encode(Schema.t(), term) ::
-          {:ok, encoded_avro}
-          | {:error, :unmatching_schema}
-          | {:error, term(), term}
+          {:ok, encoded_avro} | {:error, AvroEx.EncodeError.t() | Exception.t()}
   def encode(schema, data) do
     AvroEx.Encode.encode(schema, data)
   end

--- a/lib/avro_ex.ex
+++ b/lib/avro_ex.ex
@@ -64,6 +64,16 @@ defmodule AvroEx do
   end
 
   @doc """
+  Same as `encode/2`, but returns the encoded value directly and raises on errors
+  """
+  def encode!(schema, data) do
+    case AvroEx.Encode.encode(schema, data) do
+      {:ok, data} -> data
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc """
   Given an encoded message and its accompanying schema, decodes the message.
   """
   @spec decode(Schema.t(), encoded_avro) ::

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -2,7 +2,13 @@ defmodule AvroEx.EncodeError do
   defexception [:message]
 
   def new({:schema_mismatch, schema, value, _context}) do
-    %__MODULE__{message: "Schema Mismatch: Expected value to match #{inspect(schema)} , got #{inspect(value)}"}
+    name =
+      case {schema, AvroEx.Schema.full_name(schema)} do
+        {schema, nil} -> AvroEx.Schema.type_name(schema)
+        {_schema, name} -> name
+      end
+
+    %__MODULE__{message: "Schema Mismatch: Expected value to match #{inspect(name)}, got #{inspect(value)}"}
   end
 
   def new({:invalid_string, str, _context}) do

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -12,8 +12,10 @@ defmodule AvroEx.EncodeError do
   end
 
   def new({:invalid_symbol, enum, value, _context}) do
+    type = AvroEx.Schema.type_name(enum)
+
     %__MODULE__{
-      message: "Invalid symbol for #{enum.name}. Expected value in #{inspect(enum.symbols)}, got #{inspect(value)}"
+      message: "Invalid symbol for #{type}. Expected value in #{inspect(enum.symbols)}, got #{inspect(value)}"
     }
   end
 

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -2,13 +2,9 @@ defmodule AvroEx.EncodeError do
   defexception [:message]
 
   def new({:schema_mismatch, schema, value, _context}) do
-    name =
-      case {schema, AvroEx.Schema.full_name(schema)} do
-        {schema, nil} -> AvroEx.Schema.type_name(schema)
-        {_schema, name} -> name
-      end
+    type = AvroEx.Schema.type_name(schema)
 
-    %__MODULE__{message: "Schema Mismatch: Expected value to match #{inspect(name)}, got #{inspect(value)}"}
+    %__MODULE__{message: "Schema Mismatch: Expected value of #{type}, got #{inspect(value)}"}
   end
 
   def new({:invalid_string, str, _context}) do
@@ -22,8 +18,10 @@ defmodule AvroEx.EncodeError do
   end
 
   def new({:incorrect_fixed_size, fixed, binary, _context}) do
+    type = AvroEx.Schema.type_name(fixed)
+
     %__MODULE__{
-      message: "Fixed has incorrect size #{inspect(fixed.name)}. Expected #{fixed.size}, got #{byte_size(binary)}"
+      message: "#{type} has incorrect size. Expected #{fixed.size}, got #{byte_size(binary)}"
     }
   end
 end

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -4,7 +4,7 @@ defmodule AvroEx.Encode do
   require Bitwise
 
   alias AvroEx.EncodeError
-  alias AvroEx.Schema
+  alias AvroEx.{Schema}
   alias AvroEx.Schema.{Array, Context, Fixed, Primitive, Record, Union}
   alias AvroEx.Schema.Enum, as: AvroEnum
   alias AvroEx.Schema.Record.Field

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -1,6 +1,9 @@
 defmodule AvroEx.EncodeError do
   defexception [:message]
 
+  @type t :: %__MODULE__{}
+
+  @spec new(tuple()) :: t()
   def new({:schema_mismatch, schema, value, _context}) do
     type = AvroEx.Schema.type_name(schema)
 

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -1,36 +1,3 @@
-defmodule AvroEx.EncodeError do
-  defexception [:message]
-
-  @type t :: %__MODULE__{}
-
-  @spec new(tuple()) :: t()
-  def new({:schema_mismatch, schema, value, _context}) do
-    type = AvroEx.Schema.type_name(schema)
-
-    %__MODULE__{message: "Schema Mismatch: Expected value of #{type}, got #{inspect(value)}"}
-  end
-
-  def new({:invalid_string, str, _context}) do
-    %__MODULE__{message: "Invalid string \"#{inspect(str)}\""}
-  end
-
-  def new({:invalid_symbol, enum, value, _context}) do
-    type = AvroEx.Schema.type_name(enum)
-
-    %__MODULE__{
-      message: "Invalid symbol for #{type}. Expected value in #{inspect(enum.symbols)}, got #{inspect(value)}"
-    }
-  end
-
-  def new({:incorrect_fixed_size, fixed, binary, _context}) do
-    type = AvroEx.Schema.type_name(fixed)
-
-    %__MODULE__{
-      message: "Invalid size for #{type}. Size of #{byte_size(binary)} for #{inspect(binary)}"
-    }
-  end
-end
-
 defmodule AvroEx.Encode do
   @moduledoc false
 
@@ -277,6 +244,6 @@ defmodule AvroEx.Encode do
 
   @compile {:inline, error: 1}
   defp error(error) do
-    throw(AvroEx.EncodeError.new(error))
+    error |> AvroEx.EncodeError.new() |> throw()
   end
 end

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -26,7 +26,7 @@ defmodule AvroEx.EncodeError do
     type = AvroEx.Schema.type_name(fixed)
 
     %__MODULE__{
-      message: "#{type} has incorrect size. Expected #{fixed.size}, got #{byte_size(binary)}"
+      message: "Invalid size for #{type}. Size of #{byte_size(binary)} for #{inspect(binary)}"
     }
   end
 end

--- a/lib/avro_ex/encode_error.ex
+++ b/lib/avro_ex/encode_error.ex
@@ -1,0 +1,35 @@
+defmodule AvroEx.EncodeError do
+  @moduledoc """
+  Exceptions in encoding Avro data
+  """
+  defexception [:message]
+
+  @type t :: %__MODULE__{}
+
+  @spec new(tuple()) :: t()
+  def new({:schema_mismatch, schema, value, _context}) do
+    type = AvroEx.Schema.type_name(schema)
+
+    %__MODULE__{message: "Schema Mismatch: Expected value of #{type}, got #{inspect(value)}"}
+  end
+
+  def new({:invalid_string, str, _context}) do
+    %__MODULE__{message: "Invalid string \"#{inspect(str)}\""}
+  end
+
+  def new({:invalid_symbol, enum, value, _context}) do
+    type = AvroEx.Schema.type_name(enum)
+
+    %__MODULE__{
+      message: "Invalid symbol for #{type}. Expected value in #{inspect(enum.symbols)}, got #{inspect(value)}"
+    }
+  end
+
+  def new({:incorrect_fixed_size, fixed, binary, _context}) do
+    type = AvroEx.Schema.type_name(fixed)
+
+    %__MODULE__{
+      message: "Invalid size for #{type}. Size of #{byte_size(binary)} for #{inspect(binary)}"
+    }
+  end
+end

--- a/lib/avro_ex/schema.ex
+++ b/lib/avro_ex/schema.ex
@@ -37,7 +37,7 @@ defmodule AvroEx.Schema do
   def parse(json_schema, %Context{} = context \\ %Context{}) do
     with {:ok, schema} <- Jason.decode(json_schema),
          {:ok, schema} <- cast(schema),
-         {:ok, schema} <- namespace(schema),
+         {:ok, schema} <- propagate_namespace(schema),
          {:ok, context} <- expand(schema, context) do
       {:ok, %__MODULE__{schema: schema, context: context}}
     end
@@ -160,20 +160,18 @@ defmodule AvroEx.Schema do
 
   def encodable?(_, _, _), do: false
 
-  @spec namespace(any()) :: {:ok, any()}
-  def namespace(schema) do
-    {:ok, namespace(schema, nil)}
+  defp propagate_namespace(schema) do
+    {:ok, propagate_namespace(schema, nil)}
   end
 
-  @spec namespace(any(), any()) :: any()
-  def namespace(%Primitive{} = primitive, _parent_namespace), do: primitive
+  defp propagate_namespace(%Primitive{} = primitive, _parent_namespace), do: primitive
 
-  def namespace(%Record{} = record, parent_namespace) do
+  defp propagate_namespace(%Record{} = record, parent_namespace) do
     record = qualify_namespace(record)
 
     fields =
       Enum.map(record.fields, fn field ->
-        namespace(field, record.namespace || parent_namespace)
+        propagate_namespace(field, record.namespace || parent_namespace)
       end)
 
     full_names = full_names(record, parent_namespace)
@@ -181,40 +179,40 @@ defmodule AvroEx.Schema do
     %Record{record | fields: fields, qualified_names: full_names}
   end
 
-  def namespace(%Field{} = field, parent_namespace) do
-    type = namespace(field.type, parent_namespace)
+  defp propagate_namespace(%Field{} = field, parent_namespace) do
+    type = propagate_namespace(field.type, parent_namespace)
     %Field{field | type: type}
   end
 
-  def namespace(%Union{possibilities: possibilities} = union, parent_namespace) do
-    possibilities = Enum.map(possibilities, &namespace(&1, parent_namespace))
+  defp propagate_namespace(%Union{possibilities: possibilities} = union, parent_namespace) do
+    possibilities = Enum.map(possibilities, &propagate_namespace(&1, parent_namespace))
     %Union{union | possibilities: possibilities}
   end
 
-  def namespace(%Fixed{} = fixed, parent_namespace) do
+  defp propagate_namespace(%Fixed{} = fixed, parent_namespace) do
     fixed = qualify_namespace(fixed)
     %Fixed{fixed | qualified_names: full_names(fixed, parent_namespace)}
   end
 
-  def namespace(%AvroMap{} = map, parent_namespace) do
-    values = namespace(map.values, parent_namespace)
+  defp propagate_namespace(%AvroMap{} = map, parent_namespace) do
+    values = propagate_namespace(map.values, parent_namespace)
     %AvroMap{map | values: values}
   end
 
-  def namespace(%Array{} = array, parent_namespace) do
-    %Array{array | items: namespace(array.items, parent_namespace)}
+  defp propagate_namespace(%Array{} = array, parent_namespace) do
+    %Array{array | items: propagate_namespace(array.items, parent_namespace)}
   end
 
-  def namespace(%AvroEnum{} = enum, _) do
+  defp propagate_namespace(%AvroEnum{} = enum, _) do
     enum = qualify_namespace(enum)
     %AvroEnum{enum | qualified_names: full_names(enum, enum.namespace)}
   end
 
-  def namespace(name, nil) do
+  defp propagate_namespace(name, nil) do
     name
   end
 
-  def namespace(str, parent_namespace) when is_binary(str) do
+  defp propagate_namespace(str, parent_namespace) when is_binary(str) do
     if String.match?(str, ~r/\./) do
       str
     else
@@ -253,6 +251,12 @@ defmodule AvroEx.Schema do
     [full_name(namespace || parent_namespace, record.name) | full_aliases]
   end
 
+  def full_name(%struct{}) when struct in [Array, AvroMap, Primitive, Union], do: nil
+
+  def full_name(%struct{name: name, namespace: namespace}) when struct in [Fixed, Record, AvroEnum] do
+    full_name(namespace, name)
+  end
+
   @spec full_name(namespace, name) :: full_name
   def full_name(nil, name) when is_binary(name) do
     name
@@ -265,6 +269,15 @@ defmodule AvroEx.Schema do
       "#{namespace}.#{name}"
     end
   end
+
+  def type_name(%Primitive{type: type}), do: to_string(type)
+
+  def type_name(%Array{}), do: "array"
+  def type_name(%Union{}), do: "union"
+  def type_name(%Record{}), do: "record"
+  def type_name(%Fixed{}), do: "fixed"
+  def type_name(%AvroEnum{}), do: "enum"
+  def type_name(%AvroMap{}), do: "map"
 
   @spec cast_schema(atom(), map(), any()) :: {:error, any()} | {:ok, map()}
   def cast_schema(module, data, fields) do

--- a/lib/avro_ex/schema.ex
+++ b/lib/avro_ex/schema.ex
@@ -251,6 +251,16 @@ defmodule AvroEx.Schema do
     [full_name(namespace || parent_namespace, record.name) | full_aliases]
   end
 
+  @doc """
+  The fully-qualified name of the type
+
+  iex> full_name(%Primitive{type: "string"})
+  nil
+
+  iex> full_name(%Record{name: "foo", namespace: "beam.community"})
+  "beam.community.foo"
+  """
+  @spec full_name(schema_types()) :: nil | String.t()
   def full_name(%struct{}) when struct in [Array, AvroMap, Primitive, Union], do: nil
 
   def full_name(%struct{name: name, namespace: namespace}) when struct in [Fixed, Record, AvroEnum] do
@@ -271,6 +281,8 @@ defmodule AvroEx.Schema do
   end
 
   @doc """
+  The name of the schema type
+
   iex> type_name(%Primitive{type: "string"})
   "string"
 
@@ -292,6 +304,7 @@ defmodule AvroEx.Schema do
   iex> type_name(%Record{name: "foo"})
   "Record<name=foo>"
   """
+  @spec type_name(schema_types()) :: String.t()
   def type_name(%Primitive{type: nil}), do: "null"
   def type_name(%Primitive{metadata: %{"logicalType" => type}}), do: type
   def type_name(%Primitive{type: type}), do: to_string(type)

--- a/lib/avro_ex/schema.ex
+++ b/lib/avro_ex/schema.ex
@@ -270,14 +270,15 @@ defmodule AvroEx.Schema do
     end
   end
 
+  def type_name(%Primitive{type: nil}), do: "null"
   def type_name(%Primitive{type: type}), do: to_string(type)
 
-  def type_name(%Array{}), do: "array"
-  def type_name(%Union{}), do: "union"
-  def type_name(%Record{}), do: "record"
-  def type_name(%Fixed{}), do: "fixed"
-  def type_name(%AvroEnum{}), do: "enum"
-  def type_name(%AvroMap{}), do: "map"
+  def type_name(%Array{items: type}), do: "Array<items=#{type}>"
+  def type_name(%Union{possibilities: types}), do: "Union<possibilities=#{Enum.map_join(types, "|", &type_name/1)}>"
+  def type_name(%Record{} = record), do: "Record<name=#{full_name(record)}>"
+  def type_name(%Fixed{size: size} = fixed), do: "Fixed<name=#{full_name(fixed)}, size=#{size}>"
+  def type_name(%AvroEnum{} = enum), do: "Enum<name=#{full_name(enum)}"
+  def type_name(%AvroMap{values: values}), do: "Map<values=#{values}>"
 
   @spec cast_schema(atom(), map(), any()) :: {:error, any()} | {:ok, map()}
   def cast_schema(module, data, fields) do

--- a/lib/avro_ex/schema.ex
+++ b/lib/avro_ex/schema.ex
@@ -270,14 +270,37 @@ defmodule AvroEx.Schema do
     end
   end
 
+  @doc """
+  iex> type_name(%Primitive{type: "string"})
+  "string"
+
+  iex> type_name(%Primitive{type: :long, metadata: %{"logicalType" => "timestamp-millis"}})
+  "timestamp-millis"
+
+  iex> type_name(%AvroEnum{name: "switch"})
+  "Enum<name=switch>"
+
+  iex> type_name(%Array{items: "int"})
+  "Array<items=int>"
+
+  iex> type_name(%Fixed{size: 2, name: "double"})
+  "Fixed<name=double, size=2>"
+
+  iex> type_name(%Union{possibilities: [%Primitive{type: "string"}, %Primitive{type: "int"}]})
+  "Union<possibilities=string|int>"
+
+  iex> type_name(%Record{name: "foo"})
+  "Record<name=foo>"
+  """
   def type_name(%Primitive{type: nil}), do: "null"
+  def type_name(%Primitive{metadata: %{"logicalType" => type}}), do: type
   def type_name(%Primitive{type: type}), do: to_string(type)
 
   def type_name(%Array{items: type}), do: "Array<items=#{type}>"
   def type_name(%Union{possibilities: types}), do: "Union<possibilities=#{Enum.map_join(types, "|", &type_name/1)}>"
   def type_name(%Record{} = record), do: "Record<name=#{full_name(record)}>"
   def type_name(%Fixed{size: size} = fixed), do: "Fixed<name=#{full_name(fixed)}, size=#{size}>"
-  def type_name(%AvroEnum{} = enum), do: "Enum<name=#{full_name(enum)}"
+  def type_name(%AvroEnum{} = enum), do: "Enum<name=#{full_name(enum)}>"
   def type_name(%AvroMap{values: values}), do: "Map<values=#{values}>"
 
   @spec cast_schema(atom(), map(), any()) :: {:error, any()} | {:ok, map()}

--- a/lib/avro_ex/schema.ex
+++ b/lib/avro_ex/schema.ex
@@ -292,8 +292,8 @@ defmodule AvroEx.Schema do
   iex> type_name(%AvroEnum{name: "switch"})
   "Enum<name=switch>"
 
-  iex> type_name(%Array{items: "int"})
-  "Array<items=int>"
+  iex> type_name(%Array{items: %Primitive{type: "integer"}})
+  "Array<items=integer>"
 
   iex> type_name(%Fixed{size: 2, name: "double"})
   "Fixed<name=double, size=2>"
@@ -309,12 +309,12 @@ defmodule AvroEx.Schema do
   def type_name(%Primitive{metadata: %{"logicalType" => type}}), do: type
   def type_name(%Primitive{type: type}), do: to_string(type)
 
-  def type_name(%Array{items: type}), do: "Array<items=#{type}>"
+  def type_name(%Array{items: type}), do: "Array<items=#{type_name(type)}>"
   def type_name(%Union{possibilities: types}), do: "Union<possibilities=#{Enum.map_join(types, "|", &type_name/1)}>"
   def type_name(%Record{} = record), do: "Record<name=#{full_name(record)}>"
   def type_name(%Fixed{size: size} = fixed), do: "Fixed<name=#{full_name(fixed)}, size=#{size}>"
   def type_name(%AvroEnum{} = enum), do: "Enum<name=#{full_name(enum)}>"
-  def type_name(%AvroMap{values: values}), do: "Map<values=#{values}>"
+  def type_name(%AvroMap{values: values}), do: "Map<values=#{type_name(values)}>"
 
   @spec cast_schema(atom(), map(), any()) :: {:error, any()} | {:ok, map()}
   def cast_schema(module, data, fields) do

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -322,16 +322,22 @@ defmodule AvroEx.Encode.Test do
       {:ok, schema} = AvroEx.parse_schema(~S({"type": "fixed", "name": "sha", "size": 40}))
       bad_sha = binary_of_size(39)
 
-      assert {:error, %AvroEx.EncodeError{message: "Fixed<name=sha, size=40> has incorrect size. Expected 40, got 39"}} =
-               @test_module.encode(schema, bad_sha)
+      assert {:error,
+              %AvroEx.EncodeError{
+                message:
+                  "Invalid size for Fixed<name=sha, size=40>. Size of 39 for \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+              }} = @test_module.encode(schema, bad_sha)
     end
 
     test "fails if the value is too large" do
       {:ok, schema} = AvroEx.parse_schema(~S({"type": "fixed", "name": "sha", "size": 40}))
       bad_sha = binary_of_size(41)
 
-      assert {:error, %AvroEx.EncodeError{message: "Fixed<name=sha, size=40> has incorrect size. Expected 40, got 41"}} =
-               @test_module.encode(schema, bad_sha)
+      assert {:error,
+              %AvroEx.EncodeError{
+                message:
+                  "Invalid size for Fixed<name=sha, size=40>. Size of 41 for \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+              }} = @test_module.encode(schema, bad_sha)
     end
   end
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -362,7 +362,24 @@ defmodule AvroEx.Encode.Test do
     test "returns the expected error tuple" do
       {:ok, schema} = AvroEx.parse_schema(~S("null"))
 
-      assert {:error, :data_does_not_match_schema, :wat, _schema} = @test_module.encode(schema, :wat)
+      assert {:error,
+              %AvroEx.EncodeError{
+                message:
+                  "Schema Mismatch: Expected value to match %AvroEx.Schema.Primitive{metadata: %{}, type: nil}, got :wat"
+              }} = @test_module.encode(schema, :wat)
+    end
+
+    test "returns the expected error tuple for a complex type" do
+      assert schema =
+               AvroEx.parse_schema!(~S({"type": "record", "namespace": "beam.community", "name": "Name", "fields": [
+        {"type": "string", "name": "first"},
+        {"type": "string", "name": "last"}
+      ]}))
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Schema Mismatch: Expected value to match beam.community.Name, got :wat"
+              }} = @test_module.encode(schema, :wat)
     end
   end
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -194,18 +194,6 @@ defmodule AvroEx.Encode.Test do
       assert {:ok, <<0>>} = @test_module.encode(schema, %{})
       assert {:ok, <<2, 2, 49>>} = @test_module.encode(schema, %{"maybe_null" => "1"})
     end
-
-    test "returns an error if it doesn't match the schema" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "record", "name": "Record", "fields": [
-        {"type": "string", "name": "first"},
-        {"type": "string", "name": "last"}
-        ]}))
-
-      assert {:ok, "\bDave\nLucia"} = @test_module.encode(schema, %{"first" => "Dave", "last" => "Lucia"})
-
-      assert {:error, %AvroEx.EncodeError{message: "Schema Mismatch: Expected value of string, got nil"}} =
-               @test_module.encode(schema, %{})
-    end
   end
 
   describe "encode (union)" do
@@ -318,17 +306,6 @@ defmodule AvroEx.Encode.Test do
       assert encoded == sha
     end
 
-    test "fails if the value is too small" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "fixed", "name": "sha", "size": 40}))
-      bad_sha = binary_of_size(39)
-
-      assert {:error,
-              %AvroEx.EncodeError{
-                message:
-                  "Invalid size for Fixed<name=sha, size=40>. Size of 39 for \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
-              }} = @test_module.encode(schema, bad_sha)
-    end
-
     test "fails if the value is too large" do
       {:ok, schema} = AvroEx.parse_schema(~S({"type": "fixed", "name": "sha", "size": 40}))
       bad_sha = binary_of_size(41)
@@ -367,8 +344,8 @@ defmodule AvroEx.Encode.Test do
     end
   end
 
-  describe "Doesn't match schema" do
-    test "returns the expected error tuple" do
+  describe "EncodingError - schema mismatch" do
+    test "(null)" do
       {:ok, schema} = AvroEx.parse_schema(~S("null"))
 
       assert {:error,
@@ -377,7 +354,53 @@ defmodule AvroEx.Encode.Test do
               }} = @test_module.encode(schema, :wat)
     end
 
-    test "returns the expected error tuple for a complex type" do
+    test "(integer)" do
+      {:ok, schema} = AvroEx.parse_schema(~S("int"))
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Schema Mismatch: Expected value of integer, got :wat"
+              }} = @test_module.encode(schema, :wat)
+    end
+
+    test "(array)" do
+      schema = AvroEx.parse_schema!(~S({"type": "array", "items": "int"}))
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Schema Mismatch: Expected value of Array<items=integer>, got :wat"
+              }} = @test_module.encode(schema, :wat)
+    end
+
+    test "(enum)" do
+      schema =
+        AvroEx.parse_schema!(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Schema Mismatch: Expected value of Enum<name=Suit>, got 12345"
+              }} = @test_module.encode(schema, 12_345)
+    end
+
+    test "(fixed)" do
+      schema = AvroEx.parse_schema!(~S({"type": "fixed", "name": "sha", "size": 40}))
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Schema Mismatch: Expected value of Fixed<name=sha, size=40>, got 12345"
+              }} = @test_module.encode(schema, 12_345)
+    end
+
+    test "(map)" do
+      schema = AvroEx.parse_schema!(~S({"type": "map", "values": "int"}))
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Schema Mismatch: Expected value of Map<values=integer>, got 12345"
+              }} = @test_module.encode(schema, 12_345)
+    end
+
+    test "(record)" do
       assert schema =
                AvroEx.parse_schema!(~S({"type": "record", "namespace": "beam.community", "name": "Name", "fields": [
         {"type": "string", "name": "first"},
@@ -388,6 +411,57 @@ defmodule AvroEx.Encode.Test do
               %AvroEx.EncodeError{
                 message: "Schema Mismatch: Expected value of Record<name=beam.community.Name>, got :wat"
               }} = @test_module.encode(schema, :wat)
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Schema Mismatch: Expected value of string, got nil"
+              }} = @test_module.encode(schema, %{})
+    end
+
+    test "(union)" do
+      schema = AvroEx.parse_schema!(~S(["null", "string"]))
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Schema Mismatch: Expected value of Union<possibilities=null|string>, got 12345"
+              }} = @test_module.encode(schema, 12_345)
+    end
+  end
+
+  describe "EncodingError - Invalid Fixed size" do
+    test "(fixed)" do
+      schema = AvroEx.parse_schema!(~S({"type": "fixed", "name": "sha", "size": 40}))
+      bad_sha = binary_of_size(39)
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message:
+                  "Invalid size for Fixed<name=sha, size=40>. Size of 39 for \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""
+              }} = @test_module.encode(schema, bad_sha)
+    end
+  end
+
+  describe "EncodingError - Invalid Symbol" do
+    test "(enum)" do
+      schema =
+        AvroEx.parse_schema!(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message:
+                  "Invalid symbol for Enum<name=Suit>. Expected value in [\"heart\", \"spade\", \"diamond\", \"club\"], got \"joker\""
+              }} = @test_module.encode(schema, "joker")
+    end
+  end
+
+  describe "EncodingError - Invalid string" do
+    test "(fixed)" do
+      schema = AvroEx.parse_schema!(~S("string"))
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Invalid string \"<<255, 255>>\""
+              }} = @test_module.encode(schema, <<0xFFFF::16>>)
     end
   end
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -55,14 +55,14 @@ defmodule AvroEx.Encode.Test do
       assert {:ok, <<14, 97, 98, 99, 100, 101, 102, 103>>} = @test_module.encode(schema, "abcdefg")
       assert {:ok, <<14, 97, 98, 99, 100, 101, 102, 103>>} = @test_module.encode(schema, :abcdefg)
 
-      assert {:error, :data_does_not_match_schema, nil, %AvroEx.Schema.Primitive{metadata: %{}, type: :string}} =
-               @test_module.encode(schema, nil)
+      assert {:error, %AvroEx.EncodeError{message: message}} = @test_module.encode(schema, nil)
+      assert message == ""
 
-      assert {:error, :data_does_not_match_schema, true, %AvroEx.Schema.Primitive{metadata: %{}, type: :string}} =
-               @test_module.encode(schema, true)
+      assert {:error, %AvroEx.EncodeError{message: message}} = @test_module.encode(schema, true)
+      assert message == ""
 
-      assert {:error, :data_does_not_match_schema, false, %AvroEx.Schema.Primitive{metadata: %{}, type: :string}} =
-               @test_module.encode(schema, false)
+      assert {:error, %AvroEx.EncodeError{message: message}} = @test_module.encode(schema, false)
+      assert message == ""
     end
   end
 

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -8,7 +8,9 @@ defmodule AvroEx.Schema.Test do
   alias AvroEx.Schema.Enum, as: AvroEnum
   alias AvroEx.Schema.Map, as: AvroMap
   alias AvroEx.Schema.Record.Field
-  alias AvroEx.Schema.{Array, Context, Primitive, Record, Union}
+  alias AvroEx.Schema.{Array, Context, Fixed, Primitive, Record, Union}
+
+  doctest AvroEx.Schema, import: true
 
   @test_module AvroEx.Schema
 


### PR DESCRIPTION
Contributes to #50 

1. Adds an exception called `AvroEx.EncodeError`
2. `AvroEx.Encode.encode/2` now only returns `{:error,
AvroEx.EncodeError.t()}` in the event of an error. This will include a
nice error message
3. Add `AvroEx.encode!/2` that will raise `AvroEx.EncodeError` in the
event of an exception

- [x] Include the type of the schema when appropriate in the error
message
- [x] Add `AvroEx.encode!/2`
- [x] Test coverage for all exceptions