### PR TITLE
Implement String.Chars protocol for Schema types

### DIFF
--- a/lib/avro_ex/schema/array.ex
+++ b/lib/avro_ex/schema/array.ex
@@ -53,4 +53,10 @@ defmodule AvroEx.Schema.Array do
   end
 
   def match?(_array, _context, _data), do: false
+
+  defimpl String.Chars do
+    def to_string(fixed) do
+      "Fixed#{fixed.size}(#{Schema.full_name(fixed.namespace, fixed.name)})"
+    end
+  end
 end

--- a/lib/avro_ex/schema/enum.ex
+++ b/lib/avro_ex/schema/enum.ex
@@ -51,4 +51,10 @@ defmodule AvroEx.Schema.Enum do
   end
 
   def match?(_enum, _context, _data), do: false
+
+  defimpl String.Chars do
+    def to_string(%{name: name, namespace: namespace}) do
+      "Enum(#{Schema.full_name(namespace, name)})"
+    end
+  end
 end

--- a/lib/avro_ex/schema/fixed.ex
+++ b/lib/avro_ex/schema/fixed.ex
@@ -44,4 +44,10 @@ defmodule AvroEx.Schema.Fixed do
   end
 
   def match?(_fixed, _context, _data), do: false
+
+  defimpl String.Chars do
+    def to_string(fixed) do
+      "Fixed#{fixed.size}(#{Schema.full_name(fixed.namespace, fixed.name)})"
+    end
+  end
 end

--- a/lib/avro_ex/schema/primitive.ex
+++ b/lib/avro_ex/schema/primitive.ex
@@ -62,4 +62,13 @@ defmodule AvroEx.Schema.Primitive do
   def type("double"), do: :double
   def type("bytes"), do: :bytes
   def type("string"), do: :string
+
+  defimpl String.Chars do
+    def to_string(%{metadata: %{"logicalType" => type}}) do
+      type
+    end
+
+    def to_string(%{type: nil}), do: "null"
+    def to_string(%{type: type}), do: Atom.to_string(type)
+  end
 end

--- a/test/to_string_test.exs
+++ b/test/to_string_test.exs
@@ -1,0 +1,62 @@
+defmodule AvroEx.ToStringTest do
+  use ExUnit.Case
+
+  alias AvroEx.Schema
+  alias AvroEx.Schema.Array
+  alias AvroEx.Schema.Enum, as: AvroEnum
+  alias AvroEx.Schema.Fixed
+  alias AvroEx.Schema.Primitive
+
+  describe "primitive" do
+    @primitives [
+      {"null", "null"},
+      "boolean",
+      "int",
+      "long",
+      "float",
+      "double",
+      "bytes",
+      "string"
+    ]
+    test "can be to_string" do
+      for t <- @primitives do
+        {:ok, type} = Primitive.cast(t)
+        assert to_string(type) == t
+      end
+    end
+  end
+
+  describe "enum" do
+    test "uses the name" do
+      assert %Schema{schema: %AvroEnum{} = enum} =
+               AvroEx.parse_schema!(~S({"type": "enum", "name": "Cool", "symbols": ["a", "b"]}))
+
+      assert to_string(enum) == "Enum(Cool)"
+    end
+
+    test "includes the namespace if one is available" do
+      assert %Schema{schema: %AvroEnum{} = enum} =
+               AvroEx.parse_schema!(
+                 ~S({"type": "enum", "namespace": "beam.community", "name": "Cool", "symbols": ["a", "b"]})
+               )
+
+      assert to_string(enum) == "Enum(beam.community.Cool)"
+    end
+  end
+
+  describe "fixed" do
+    test "shows the size" do
+      assert %Schema{schema: %Fixed{} = fixed} =
+               AvroEx.parse_schema!(~S({"type": "fixed", "name": "toofer", "size": "2"}))
+
+      assert to_string(fixed) == "Fixed2(toofer)"
+    end
+
+    test "includes the namespace if one is available" do
+      assert %Schema{schema: %Fixed{} = fixed} =
+               AvroEx.parse_schema!(~S({"type": "fixed", "namespace": "beam.community", "name": "quad", "size": "4"}))
+
+      assert to_string(fixed) == "Fixed4(beam.community.quad)"
+    end
+  end
+end


### PR DESCRIPTION
This might be a bad choice, but for #53 I need a convenient way to get
the name of the type. I thought I could use `to_string(%Enum{})` for
example, to get the type and display it in the error message.

Counter argument for doing this is that we might want to show a fuller
representation of the type. Thoughts?

- [x] Primitive
- [x] Enum
- [x] Fixed
- [ ] Array
- [ ] Map
- [ ] Record
- [ ] Union