### PR TITLE
Deprecate parse_schema/1 and rename to `decode_schema/1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ### Added
 * `AvroEx.encode!/2` - identical to `encode/2`, but raises
+* `AvroEx.decode_schema/1` and `AvroEx.decode_schema!/` in place of `AvroEx.parse_schema/1`
+
+### Deprecated
+* `AvroEx.parse_schema/1`
+* `AvroEx.parse_schema!/1`
 
 ## v1.2.0
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ defmodule MyWorker do
     {:ok, decoded_message} =
       @schema_id
       |> SchemaRepository.fetch_schema
-      |> AvroEx.parse_schema!
+      |> AvroEx.decode_schema!
       |> AvroEx.decode(message)
 
     # And do things with the message

--- a/lib/avro_ex.ex
+++ b/lib/avro_ex.ex
@@ -29,25 +29,32 @@ defmodule AvroEx do
   """
   defdelegate encodable?(schema, data), to: AvroEx.Schema
 
-  @spec parse_schema(Schema.json_schema()) ::
-          {:ok, Schema.t()}
-          | {:error, :unnamed_record}
-          | {:error, :invalid_json}
+  @deprecated "Use AvroEx.decode_schema/1 instead"
+  def parse_schema(json), do: decode_schema(json)
+
+  @deprecated "Use AvroEx.decode_schema!/1 instead"
+  def parse_schema!(json), do: decode_schema!(json)
+
   @doc """
   Given a JSON-formatted schema, parses the schema and returns a `%AvroEx.Schema{}` struct representing the schema.
   Errors if the JSON is invalid, or if a named record is referenced that doesn't exist.
   """
-  def parse_schema(json_schema) do
-    Schema.parse(json_schema)
+  @spec decode_schema(Schema.json_schema()) ::
+          {:ok, Schema.t()}
+          | {:error, :unnamed_record}
+          | {:error, :invalid_json}
+
+  def decode_schema(json) do
+    Schema.parse(json)
   end
 
-  @spec parse_schema!(Schema.json_schema()) :: Schema.t() | no_return
   @doc """
-  Same as `AvroEx.parse_schema/1`, but raises an exception on failure instead of
+  Same as `AvroEx.decode_schema/1`, but raises an exception on failure instead of
   returning an error tuple.
   """
-  def parse_schema!(json_schema) do
-    case parse_schema(json_schema) do
+  @spec decode_schema!(Schema.json_schema()) :: Schema.t() | no_return
+  def decode_schema!(json) do
+    case decode_schema(json) do
       {:ok, schema} -> schema
       _ -> raise "Parsing schema failed"
     end

--- a/lib/avro_ex.ex
+++ b/lib/avro_ex.ex
@@ -29,9 +29,14 @@ defmodule AvroEx do
   """
   defdelegate encodable?(schema, data), to: AvroEx.Schema
 
+  @spec parse_schema(Schema.json_schema()) ::
+          {:ok, Schema.t()}
+          | {:error, :unnamed_record}
+          | {:error, :invalid_json}
   @deprecated "Use AvroEx.decode_schema/1 instead"
   def parse_schema(json), do: decode_schema(json)
 
+  @spec parse_schema!(Schema.json_schema()) :: Schema.t() | no_return
   @deprecated "Use AvroEx.decode_schema!/1 instead"
   def parse_schema!(json), do: decode_schema!(json)
 
@@ -43,7 +48,6 @@ defmodule AvroEx do
           {:ok, Schema.t()}
           | {:error, :unnamed_record}
           | {:error, :invalid_json}
-
   def decode_schema(json) do
     Schema.parse(json)
   end

--- a/test/avro_ex_test.exs
+++ b/test/avro_ex_test.exs
@@ -123,7 +123,7 @@ defmodule AvroEx.Schema.Primitive.Test do
                     } = record
                   ]
                 }
-              } = schema} = AvroEx.parse_schema(schema_json)
+              } = schema} = AvroEx.decode_schema(schema_json)
 
       assert AvroEx.named_type(type, schema) == record
     end
@@ -158,7 +158,7 @@ defmodule AvroEx.Schema.Primitive.Test do
                     }
                   ]
                 }
-              } = schema} = AvroEx.parse_schema(schema_json)
+              } = schema} = AvroEx.decode_schema(schema_json)
 
       data = %{
         "value" => 25,

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -5,13 +5,13 @@ defmodule AvroEx.Decode.Test do
 
   describe "decode (primitive)" do
     test "null" do
-      {:ok, schema} = AvroEx.parse_schema(~S("null"))
+      {:ok, schema} = AvroEx.decode_schema(~S("null"))
       {:ok, avro_message} = AvroEx.encode(schema, nil)
       assert {:ok, nil} = @test_module.decode(schema, avro_message)
     end
 
     test "boolean" do
-      {:ok, schema} = AvroEx.parse_schema(~S("boolean"))
+      {:ok, schema} = AvroEx.decode_schema(~S("boolean"))
       {:ok, true_message} = AvroEx.encode(schema, true)
       {:ok, false_message} = AvroEx.encode(schema, false)
 
@@ -20,7 +20,7 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "integer" do
-      {:ok, schema} = AvroEx.parse_schema(~S("int"))
+      {:ok, schema} = AvroEx.decode_schema(~S("int"))
       {:ok, zero} = AvroEx.encode(schema, 0)
       {:ok, neg_ten} = AvroEx.encode(schema, -10)
       {:ok, ten} = AvroEx.encode(schema, 10)
@@ -39,7 +39,7 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "long" do
-      {:ok, schema} = AvroEx.parse_schema(~S("long"))
+      {:ok, schema} = AvroEx.decode_schema(~S("long"))
       {:ok, zero} = AvroEx.encode(schema, 0)
       {:ok, neg_ten} = AvroEx.encode(schema, -10)
       {:ok, ten} = AvroEx.encode(schema, 10)
@@ -58,7 +58,7 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "float" do
-      {:ok, schema} = AvroEx.parse_schema(~S("float"))
+      {:ok, schema} = AvroEx.decode_schema(~S("float"))
       {:ok, zero} = AvroEx.encode(schema, 0.0)
       {:ok, big} = AvroEx.encode(schema, 256.25)
 
@@ -67,7 +67,7 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "double" do
-      {:ok, schema} = AvroEx.parse_schema(~S("double"))
+      {:ok, schema} = AvroEx.decode_schema(~S("double"))
       {:ok, zero} = AvroEx.encode(schema, 0.0)
       {:ok, big} = AvroEx.encode(schema, 256.25)
 
@@ -76,14 +76,14 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "bytes" do
-      {:ok, schema} = AvroEx.parse_schema(~S("bytes"))
+      {:ok, schema} = AvroEx.decode_schema(~S("bytes"))
       {:ok, bytes} = AvroEx.encode(schema, <<222, 213, 194, 34, 58, 92, 95, 62>>)
 
       assert {:ok, <<222, 213, 194, 34, 58, 92, 95, 62>>} = @test_module.decode(schema, bytes)
     end
 
     test "string" do
-      {:ok, schema} = AvroEx.parse_schema(~S("string"))
+      {:ok, schema} = AvroEx.decode_schema(~S("string"))
       {:ok, bytes} = AvroEx.encode(schema, "Hello there 🕶")
 
       assert {:ok, "Hello there 🕶"} = @test_module.decode(schema, bytes)
@@ -92,7 +92,7 @@ defmodule AvroEx.Decode.Test do
 
   describe "complex types" do
     test "record" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "record", "name": "MyRecord", "fields": [
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "record", "name": "MyRecord", "fields": [
         {"type": "int", "name": "a"},
         {"type": "int", "name": "b", "aliases": ["c", "d"]},
         {"type": "string", "name": "e"}
@@ -104,7 +104,7 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "union" do
-      {:ok, schema} = AvroEx.parse_schema(~S(["null", "int"]))
+      {:ok, schema} = AvroEx.decode_schema(~S(["null", "int"]))
 
       {:ok, encoded_null} = AvroEx.encode(schema, nil)
       {:ok, encoded_int} = AvroEx.encode(schema, 25)
@@ -114,7 +114,7 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "union with DateTime" do
-      {:ok, schema} = AvroEx.parse_schema(~S(["null", {"type": "long", "logicalType":"timestamp-micros"}]))
+      {:ok, schema} = AvroEx.decode_schema(~S(["null", {"type": "long", "logicalType":"timestamp-micros"}]))
       datetime = DateTime.utc_now()
 
       {:ok, encoded_null} = AvroEx.encode(schema, nil)
@@ -125,7 +125,7 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "union with Time" do
-      {:ok, schema} = AvroEx.parse_schema(~S(["null", {"type": "long", "logicalType":"time-micros"}]))
+      {:ok, schema} = AvroEx.decode_schema(~S(["null", {"type": "long", "logicalType":"time-micros"}]))
       time = Time.utc_now()
 
       {:ok, encoded_null} = AvroEx.encode(schema, nil)
@@ -136,7 +136,7 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "array" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": ["null", "int"]}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "array", "items": ["null", "int"]}))
 
       {:ok, encoded_array} = AvroEx.encode(schema, [1, 2, 3, nil, 4, 5, nil])
 
@@ -144,7 +144,7 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "empty array" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": ["null", "int"]}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "array", "items": ["null", "int"]}))
 
       {:ok, encoded_array} = AvroEx.encode(schema, [])
 
@@ -152,7 +152,7 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "map" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": ["null", "int"]}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": ["null", "int"]}))
 
       {:ok, encoded_array} = AvroEx.encode(schema, %{"a" => 1, "b" => nil, "c" => 3})
 
@@ -160,7 +160,7 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "empty map" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": ["null", "int"]}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": ["null", "int"]}))
 
       {:ok, encoded_map} = AvroEx.encode(schema, %{})
 
@@ -169,7 +169,7 @@ defmodule AvroEx.Decode.Test do
 
     test "enum" do
       {:ok, schema} =
-        AvroEx.parse_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
+        AvroEx.decode_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
 
       {:ok, club} = AvroEx.encode(schema, "club")
       {:ok, heart} = AvroEx.encode(schema, "heart")
@@ -183,14 +183,14 @@ defmodule AvroEx.Decode.Test do
     end
 
     test "fixed" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "fixed", "name": "SHA", "size": "40"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "fixed", "name": "SHA", "size": "40"}))
       sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       {:ok, encoded_sha} = AvroEx.encode(schema, sha)
       assert {:ok, ^sha} = @test_module.decode(schema, encoded_sha)
     end
 
     test "record with empty array of records" do
-      {:ok, schema} = AvroEx.parse_schema(~S(
+      {:ok, schema} = AvroEx.decode_schema(~S(
         {
           "type": "record",
           "name": "User",
@@ -229,7 +229,7 @@ defmodule AvroEx.Decode.Test do
     test "datetime micros" do
       now = DateTime.utc_now()
 
-      {:ok, micro_schema} = AvroEx.parse_schema(~S({"type": "long", "logicalType":"timestamp-micros"}))
+      {:ok, micro_schema} = AvroEx.decode_schema(~S({"type": "long", "logicalType":"timestamp-micros"}))
 
       {:ok, micro_encode} = AvroEx.encode(micro_schema, now)
       assert {:ok, ^now} = @test_module.decode(micro_schema, micro_encode)
@@ -238,7 +238,7 @@ defmodule AvroEx.Decode.Test do
     test "datetime millis" do
       now = DateTime.truncate(DateTime.utc_now(), :millisecond)
 
-      {:ok, milli_schema} = AvroEx.parse_schema(~S({"type": "long", "logicalType":"timestamp-millis"}))
+      {:ok, milli_schema} = AvroEx.decode_schema(~S({"type": "long", "logicalType":"timestamp-millis"}))
 
       {:ok, milli_encode} = AvroEx.encode(milli_schema, now)
       assert {:ok, ^now} = @test_module.decode(milli_schema, milli_encode)
@@ -247,7 +247,7 @@ defmodule AvroEx.Decode.Test do
     test "datetime nanos" do
       now = DateTime.utc_now()
 
-      {:ok, nano_schema} = AvroEx.parse_schema(~S({"type": "long", "logicalType":"timestamp-nanos"}))
+      {:ok, nano_schema} = AvroEx.decode_schema(~S({"type": "long", "logicalType":"timestamp-nanos"}))
 
       {:ok, nano_encode} = AvroEx.encode(nano_schema, now)
       assert {:ok, ^now} = @test_module.decode(nano_schema, nano_encode)
@@ -256,7 +256,7 @@ defmodule AvroEx.Decode.Test do
     test "time micros" do
       now = Time.truncate(Time.utc_now(), :microsecond)
 
-      {:ok, micro_schema} = AvroEx.parse_schema(~S({"type": "long", "logicalType":"time-micros"}))
+      {:ok, micro_schema} = AvroEx.decode_schema(~S({"type": "long", "logicalType":"time-micros"}))
       {:ok, micro_encode} = AvroEx.encode(micro_schema, now)
       assert {:ok, ^now} = @test_module.decode(micro_schema, micro_encode)
     end
@@ -264,7 +264,7 @@ defmodule AvroEx.Decode.Test do
     test "time millis" do
       now = Time.truncate(Time.utc_now(), :millisecond)
 
-      {:ok, milli_schema} = AvroEx.parse_schema(~S({"type": "int", "logicalType":"time-millis"}))
+      {:ok, milli_schema} = AvroEx.decode_schema(~S({"type": "int", "logicalType":"time-millis"}))
       {:ok, milli_encode} = AvroEx.encode(milli_schema, now)
       {:ok, time} = @test_module.decode(milli_schema, milli_encode)
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -7,50 +7,50 @@ defmodule AvroEx.Encode.Test do
 
   describe "encode (primitive)" do
     test "null" do
-      {:ok, schema} = AvroEx.parse_schema(~S("null"))
+      {:ok, schema} = AvroEx.decode_schema(~S("null"))
 
       assert {:ok, ""} = @test_module.encode(schema, nil)
     end
 
     test "boolean" do
-      {:ok, schema} = AvroEx.parse_schema(~S("boolean"))
+      {:ok, schema} = AvroEx.decode_schema(~S("boolean"))
 
       assert {:ok, <<1::8>>} = @test_module.encode(schema, true)
       assert {:ok, <<0::8>>} = @test_module.encode(schema, false)
     end
 
     test "integer" do
-      {:ok, schema} = AvroEx.parse_schema(~S("int"))
+      {:ok, schema} = AvroEx.decode_schema(~S("int"))
 
       assert {:ok, <<2::8>>} = @test_module.encode(schema, 1)
     end
 
     test "long" do
-      {:ok, schema} = AvroEx.parse_schema(~S("long"))
+      {:ok, schema} = AvroEx.decode_schema(~S("long"))
 
       assert {:ok, <<2::8>>} = @test_module.encode(schema, 1)
     end
 
     test "float" do
-      {:ok, schema} = AvroEx.parse_schema(~S("float"))
+      {:ok, schema} = AvroEx.decode_schema(~S("float"))
 
       assert {:ok, <<205, 204, 140, 63>>} = @test_module.encode(schema, 1.1)
     end
 
     test "double" do
-      {:ok, schema} = AvroEx.parse_schema(~S("double"))
+      {:ok, schema} = AvroEx.decode_schema(~S("double"))
 
       assert {:ok, <<154, 153, 153, 153, 153, 153, 241, 63>>} = @test_module.encode(schema, 1.1)
     end
 
     test "bytes" do
-      {:ok, schema} = AvroEx.parse_schema(~S("bytes"))
+      {:ok, schema} = AvroEx.decode_schema(~S("bytes"))
 
       assert {:ok, <<14, 97, 98, 99, 100, 101, 102, 103>>} = @test_module.encode(schema, "abcdefg")
     end
 
     test "string" do
-      {:ok, schema} = AvroEx.parse_schema(~S("string"))
+      {:ok, schema} = AvroEx.decode_schema(~S("string"))
 
       assert {:ok, <<14, 97, 98, 99, 100, 101, 102, 103>>} = @test_module.encode(schema, "abcdefg")
       assert {:ok, <<14, 97, 98, 99, 100, 101, 102, 103>>} = @test_module.encode(schema, :abcdefg)
@@ -107,7 +107,7 @@ defmodule AvroEx.Encode.Test do
 
   describe "encode (record)" do
     test "works as expected with primitive fields" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "record", "name": "Record", "fields": [
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "record", "name": "Record", "fields": [
         {"type": "null", "name": "null"},
         {"type": "boolean", "name": "bool"},
         {"type": "int", "name": "integer"},
@@ -129,14 +129,14 @@ defmodule AvroEx.Encode.Test do
         "bytes" => "abcdefg"
       }
 
-      {:ok, null_schema} = AvroEx.parse_schema(~S("null"))
-      {:ok, boolean_schema} = AvroEx.parse_schema(~S("boolean"))
-      {:ok, int_schema} = AvroEx.parse_schema(~S("int"))
-      {:ok, long_schema} = AvroEx.parse_schema(~S("long"))
-      {:ok, float_schema} = AvroEx.parse_schema(~S("float"))
-      {:ok, double_schema} = AvroEx.parse_schema(~S("double"))
-      {:ok, string_schema} = AvroEx.parse_schema(~S("string"))
-      {:ok, bytes_schema} = AvroEx.parse_schema(~S("bytes"))
+      {:ok, null_schema} = AvroEx.decode_schema(~S("null"))
+      {:ok, boolean_schema} = AvroEx.decode_schema(~S("boolean"))
+      {:ok, int_schema} = AvroEx.decode_schema(~S("int"))
+      {:ok, long_schema} = AvroEx.decode_schema(~S("long"))
+      {:ok, float_schema} = AvroEx.decode_schema(~S("float"))
+      {:ok, double_schema} = AvroEx.decode_schema(~S("double"))
+      {:ok, string_schema} = AvroEx.decode_schema(~S("string"))
+      {:ok, bytes_schema} = AvroEx.decode_schema(~S("bytes"))
 
       assert {:ok,
               Enum.join([
@@ -152,7 +152,7 @@ defmodule AvroEx.Encode.Test do
     end
 
     test "works as expected with default values" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "record", "name": "Record", "fields": [
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "record", "name": "Record", "fields": [
         {"type": "null", "name": "null", "default": null},
         {"type": "boolean", "name": "bool", "default": false},
         {"type": "int", "name": "integer", "default": 0},
@@ -167,7 +167,7 @@ defmodule AvroEx.Encode.Test do
     end
 
     test "can encode records with atom keys and string values" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "record", "name": "Record", "fields": [
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "record", "name": "Record", "fields": [
         {"type": "string", "name": "first"},
         {"type": "string", "name": "last"},
         {"name": "meta", "type": {
@@ -187,7 +187,7 @@ defmodule AvroEx.Encode.Test do
     end
 
     test "works as expected with default of null on union type" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "record", "name": "Record", "fields": [
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "record", "name": "Record", "fields": [
         {"type": ["null", "string"], "name": "maybe_null", "default": null}
         ]}))
 
@@ -198,9 +198,9 @@ defmodule AvroEx.Encode.Test do
 
   describe "encode (union)" do
     test "works as expected with nulls" do
-      {:ok, schema} = AvroEx.parse_schema(~S(["null", "int"]))
-      {:ok, null_schema} = AvroEx.parse_schema(~S("null"))
-      {:ok, int_schema} = AvroEx.parse_schema(~S("int"))
+      {:ok, schema} = AvroEx.decode_schema(~S(["null", "int"]))
+      {:ok, null_schema} = AvroEx.decode_schema(~S("null"))
+      {:ok, int_schema} = AvroEx.decode_schema(~S("int"))
 
       {:ok, index} = @test_module.encode(int_schema, 0)
       {:ok, encoded_null} = @test_module.encode(null_schema, nil)
@@ -210,8 +210,8 @@ defmodule AvroEx.Encode.Test do
     end
 
     test "works as expected with ints" do
-      {:ok, schema} = AvroEx.parse_schema(~S(["null", "int"]))
-      {:ok, int_schema} = AvroEx.parse_schema(~S("int"))
+      {:ok, schema} = AvroEx.decode_schema(~S(["null", "int"]))
+      {:ok, int_schema} = AvroEx.decode_schema(~S("int"))
 
       {:ok, index} = @test_module.encode(int_schema, 1)
       {:ok, encoded_int} = @test_module.encode(int_schema, 2086)
@@ -224,8 +224,8 @@ defmodule AvroEx.Encode.Test do
       datetime_json = ~S({"type": "long", "logicalType":"timestamp-millis"})
       datetime_value = ~U[2020-09-17 12:56:50.438Z]
 
-      {:ok, schema} = AvroEx.parse_schema(~s(["null", #{datetime_json}]))
-      {:ok, datetime_schema} = AvroEx.parse_schema(datetime_json)
+      {:ok, schema} = AvroEx.decode_schema(~s(["null", #{datetime_json}]))
+      {:ok, datetime_schema} = AvroEx.decode_schema(datetime_json)
 
       {:ok, index} = @test_module.encode(datetime_schema, 1)
       {:ok, encoded_datetime} = @test_module.encode(datetime_schema, datetime_value)
@@ -248,9 +248,9 @@ defmodule AvroEx.Encode.Test do
 
       json_schema = ~s(["null", #{record_json}])
 
-      {:ok, schema} = AvroEx.parse_schema(json_schema)
-      {:ok, int_schema} = AvroEx.parse_schema(~S("int"))
-      {:ok, record_schema} = AvroEx.parse_schema(record_json)
+      {:ok, schema} = AvroEx.decode_schema(json_schema)
+      {:ok, int_schema} = AvroEx.decode_schema(~S("int"))
+      {:ok, record_schema} = AvroEx.decode_schema(record_json)
 
       {:ok, index} = @test_module.encode(int_schema, 1)
       {:ok, encoded_record} = @test_module.encode(record_schema, %{"a" => 25, "b" => "hello"})
@@ -260,7 +260,7 @@ defmodule AvroEx.Encode.Test do
     end
 
     test "errors if the data doesn't match the schema" do
-      {:ok, schema} = AvroEx.parse_schema(~S(["null", "int"]))
+      {:ok, schema} = AvroEx.decode_schema(~S(["null", "int"]))
 
       assert {:error,
               %AvroEx.EncodeError{
@@ -271,43 +271,43 @@ defmodule AvroEx.Encode.Test do
 
   describe "encode (map)" do
     test "properly encodes the length, key-value pairs, and terminal byte" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": "int"}))
       assert {:ok, <<2, 12, 118, 97, 108, 117, 101, 49, 2, 0>>} = @test_module.encode(schema, %{"value1" => 1})
     end
 
     test "can encode atom keys" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": "int"}))
       assert {:ok, <<2, 12, 118, 97, 108, 117, 101, 49, 2, 0>>} = @test_module.encode(schema, %{value1: 1})
     end
 
     test "encodes an empty map" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": "int"}))
       assert {:ok, <<0>>} = @test_module.encode(schema, %{})
     end
   end
 
   describe "encode (array)" do
     test "properly encodes an array with length, items, and terminal byte" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "array", "items": "int"}))
       assert {:ok, <<6, 2, 4, 6, 0>>} = @test_module.encode(schema, [1, 2, 3])
     end
 
     test "encodes an empty array" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "array", "items": "int"}))
       assert {:ok, <<0>>} = @test_module.encode(schema, [])
     end
   end
 
   describe "encode (fixed)" do
     test "encodes the given value" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "fixed", "name": "sha", "size": 40}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "fixed", "name": "sha", "size": 40}))
       sha = binary_of_size(40)
       assert {:ok, encoded} = @test_module.encode(schema, sha)
       assert encoded == sha
     end
 
     test "fails if the value is too large" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "fixed", "name": "sha", "size": 40}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "fixed", "name": "sha", "size": 40}))
       bad_sha = binary_of_size(41)
 
       assert {:error,
@@ -321,9 +321,9 @@ defmodule AvroEx.Encode.Test do
   describe "encode (enum)" do
     test "encodes the index of the symbol" do
       {:ok, enum_schema} =
-        AvroEx.parse_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
+        AvroEx.decode_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
 
-      {:ok, long_schema} = AvroEx.parse_schema(~S("long"))
+      {:ok, long_schema} = AvroEx.decode_schema(~S("long"))
 
       {:ok, heart_index} = @test_module.encode(long_schema, 0)
       {:ok, spade_index} = @test_module.encode(long_schema, 1)
@@ -346,7 +346,7 @@ defmodule AvroEx.Encode.Test do
 
   describe "EncodingError - schema mismatch" do
     test "(null)" do
-      {:ok, schema} = AvroEx.parse_schema(~S("null"))
+      {:ok, schema} = AvroEx.decode_schema(~S("null"))
 
       assert {:error,
               %AvroEx.EncodeError{
@@ -355,7 +355,7 @@ defmodule AvroEx.Encode.Test do
     end
 
     test "(integer)" do
-      {:ok, schema} = AvroEx.parse_schema(~S("int"))
+      {:ok, schema} = AvroEx.decode_schema(~S("int"))
 
       assert {:error,
               %AvroEx.EncodeError{
@@ -364,7 +364,7 @@ defmodule AvroEx.Encode.Test do
     end
 
     test "(array)" do
-      schema = AvroEx.parse_schema!(~S({"type": "array", "items": "int"}))
+      schema = AvroEx.decode_schema!(~S({"type": "array", "items": "int"}))
 
       assert {:error,
               %AvroEx.EncodeError{
@@ -374,7 +374,7 @@ defmodule AvroEx.Encode.Test do
 
     test "(enum)" do
       schema =
-        AvroEx.parse_schema!(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
+        AvroEx.decode_schema!(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
 
       assert {:error,
               %AvroEx.EncodeError{
@@ -383,7 +383,7 @@ defmodule AvroEx.Encode.Test do
     end
 
     test "(fixed)" do
-      schema = AvroEx.parse_schema!(~S({"type": "fixed", "name": "sha", "size": 40}))
+      schema = AvroEx.decode_schema!(~S({"type": "fixed", "name": "sha", "size": 40}))
 
       assert {:error,
               %AvroEx.EncodeError{
@@ -392,7 +392,7 @@ defmodule AvroEx.Encode.Test do
     end
 
     test "(map)" do
-      schema = AvroEx.parse_schema!(~S({"type": "map", "values": "int"}))
+      schema = AvroEx.decode_schema!(~S({"type": "map", "values": "int"}))
 
       assert {:error,
               %AvroEx.EncodeError{
@@ -402,7 +402,7 @@ defmodule AvroEx.Encode.Test do
 
     test "(record)" do
       assert schema =
-               AvroEx.parse_schema!(~S({"type": "record", "namespace": "beam.community", "name": "Name", "fields": [
+               AvroEx.decode_schema!(~S({"type": "record", "namespace": "beam.community", "name": "Name", "fields": [
         {"type": "string", "name": "first"},
         {"type": "string", "name": "last"}
       ]}))
@@ -419,7 +419,7 @@ defmodule AvroEx.Encode.Test do
     end
 
     test "(union)" do
-      schema = AvroEx.parse_schema!(~S(["null", "string"]))
+      schema = AvroEx.decode_schema!(~S(["null", "string"]))
 
       assert {:error,
               %AvroEx.EncodeError{
@@ -430,7 +430,7 @@ defmodule AvroEx.Encode.Test do
 
   describe "EncodingError - Invalid Fixed size" do
     test "(fixed)" do
-      schema = AvroEx.parse_schema!(~S({"type": "fixed", "name": "sha", "size": 40}))
+      schema = AvroEx.decode_schema!(~S({"type": "fixed", "name": "sha", "size": 40}))
       bad_sha = binary_of_size(39)
 
       assert {:error,
@@ -444,7 +444,7 @@ defmodule AvroEx.Encode.Test do
   describe "EncodingError - Invalid Symbol" do
     test "(enum)" do
       schema =
-        AvroEx.parse_schema!(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
+        AvroEx.decode_schema!(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
 
       assert {:error,
               %AvroEx.EncodeError{
@@ -456,7 +456,7 @@ defmodule AvroEx.Encode.Test do
 
   describe "EncodingError - Invalid string" do
     test "(fixed)" do
-      schema = AvroEx.parse_schema!(~S("string"))
+      schema = AvroEx.decode_schema!(~S("string"))
 
       assert {:error,
               %AvroEx.EncodeError{

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -249,11 +249,11 @@ defmodule AvroEx.Schema.Test do
       assert {:ok,
               %@test_module{
                 schema: %@schema{}
-              }} = AvroEx.parse_schema(@json)
+              }} = AvroEx.decode_schema(@json)
     end
 
     test "matches the given type" do
-      assert {:ok, %@test_module{schema: %@schema{values: %Primitive{type: :integer}}}} = AvroEx.parse_schema(@json)
+      assert {:ok, %@test_module{schema: %@schema{values: %Primitive{type: :integer}}}} = AvroEx.decode_schema(@json)
     end
 
     test "works with a union" do
@@ -270,7 +270,7 @@ defmodule AvroEx.Schema.Test do
               }} =
                @json
                |> json_add_property(:values, ["null", "int"])
-               |> AvroEx.parse_schema()
+               |> AvroEx.decode_schema()
     end
   end
 
@@ -309,28 +309,28 @@ defmodule AvroEx.Schema.Test do
     end
 
     test "accepts atoms as strings" do
-      {:ok, schema} = AvroEx.parse_schema(~S("string"))
+      {:ok, schema} = AvroEx.decode_schema(~S("string"))
       assert @test_module.encodable?(schema, :dave)
       refute @test_module.encodable?(schema, nil)
     end
 
     test "does not accept non-utf8 strings as string" do
-      {:ok, schema} = AvroEx.parse_schema(~S("string"))
+      {:ok, schema} = AvroEx.decode_schema(~S("string"))
       refute @test_module.encodable?(schema, <<128>>)
     end
 
     test "does accept non-utf8 binaries as bytes" do
-      {:ok, schema} = AvroEx.parse_schema(~S("bytes"))
+      {:ok, schema} = AvroEx.decode_schema(~S("bytes"))
       assert @test_module.encodable?(schema, <<128>>)
     end
 
     test "does not accept non-binary bitstrings as string" do
-      {:ok, schema} = AvroEx.parse_schema(~S("string"))
+      {:ok, schema} = AvroEx.decode_schema(~S("string"))
       refute @test_module.encodable?(schema, <<0::7>>)
     end
 
     test "does not accept non-binary bitstrings as bytes" do
-      {:ok, schema} = AvroEx.parse_schema(~S("bytes"))
+      {:ok, schema} = AvroEx.decode_schema(~S("bytes"))
       refute @test_module.encodable?(schema, <<0::7>>)
     end
   end
@@ -338,21 +338,21 @@ defmodule AvroEx.Schema.Test do
   describe "parse (enum)" do
     test "doesn't blow up" do
       assert {:ok, _enum_schema} =
-               AvroEx.parse_schema(
+               AvroEx.decode_schema(
                  ~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]})
                )
     end
 
     test "returns an Enum struct" do
       assert {:ok, %Schema{schema: %AvroEnum{}}} =
-               AvroEx.parse_schema(
+               AvroEx.decode_schema(
                  ~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]})
                )
     end
 
     test "fails if the symbols aren't all strings" do
       assert {:ok, %Schema{schema: %AvroEnum{}}} =
-               AvroEx.parse_schema(
+               AvroEx.decode_schema(
                  ~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]})
                )
     end
@@ -487,84 +487,84 @@ defmodule AvroEx.Schema.Test do
 
   describe "encodable? (map)" do
     test "works as expected" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": "int"}))
       assert @test_module.encodable?(schema, %{"value" => 1, "value2" => 2, "value3" => 3})
     end
 
     test "fails if key is not a string" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": "int"}))
       refute @test_module.encodable?(schema, %{1 => 1})
     end
 
     test "fails if value does not match type" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": "int"}))
       refute @test_module.encodable?(schema, %{"value" => 1.1})
     end
 
     test "fails if one value does not match type" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": "int"}))
       refute @test_module.encodable?(schema, %{"value" => 11, "value2" => 12, "value3" => 1.1})
     end
 
     test "works with a union" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": ["null", "int"]}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": ["null", "int"]}))
       assert @test_module.encodable?(schema, %{"value" => 1, "value2" => 2, "value3" => nil})
       refute @test_module.encodable?(schema, %{"value" => 1, "value2" => 2.1, "value3" => nil})
     end
 
     test "works with an empty map" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": "int"}))
       assert @test_module.encodable?(schema, %{})
     end
 
     test "maps can have atom keys" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "map", "values": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": "int"}))
       assert @test_module.encodable?(schema, %{a: 1, b: 2})
     end
   end
 
   describe "encodable? (array)" do
     test "works as expected" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "array", "items": "int"}))
       assert @test_module.encodable?(schema, [1, 2, 3, 4, 5])
     end
 
     test "fails if item does not match type" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "array", "items": "int"}))
       refute @test_module.encodable?(schema, [1.1])
     end
 
     test "fails if one item does not match type" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "array", "items": "int"}))
       refute @test_module.encodable?(schema, [1, 2, 3, 4.5, 6])
     end
 
     test "works with a union" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": ["null", "int"]}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "array", "items": ["null", "int"]}))
       assert @test_module.encodable?(schema, [1, 2, nil, 3, 4, nil, 5])
       assert @test_module.encodable?(schema, [nil, 2, nil, 3, 4, nil, 5])
       refute @test_module.encodable?(schema, [1, 2.1, nil])
     end
 
     test "works with an empty array" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "array", "items": "int"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "array", "items": "int"}))
       assert @test_module.encodable?(schema, [])
     end
   end
 
   describe "encodable? (fixed)" do
     test "works as expected" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "fixed", "name": "SHA", "size": "40"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "fixed", "name": "SHA", "size": "40"}))
       assert @test_module.encodable?(schema, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
     end
 
     test "fails if size is too small" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "fixed", "size": "40", "name": "SHA"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "fixed", "size": "40", "name": "SHA"}))
       refute @test_module.encodable?(schema, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
     end
 
     test "fails if size is too large" do
-      {:ok, schema} = AvroEx.parse_schema(~S({"type": "fixed", "size": "40", "name": "SHA"}))
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "fixed", "size": "40", "name": "SHA"}))
       refute @test_module.encodable?(schema, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
     end
   end
@@ -572,21 +572,21 @@ defmodule AvroEx.Schema.Test do
   describe "encodable? (enum)" do
     test "works as expected" do
       {:ok, schema} =
-        AvroEx.parse_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
+        AvroEx.decode_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
 
       assert @test_module.encodable?(schema, "heart")
     end
 
     test "fails if string is not in symbols" do
       {:ok, schema} =
-        AvroEx.parse_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
+        AvroEx.decode_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
 
       refute @test_module.encodable?(schema, "kkjasdfkasdfj")
     end
 
     test "enums can have atoms" do
       {:ok, schema} =
-        AvroEx.parse_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
+        AvroEx.decode_schema(~S({"type": "enum", "name": "Suit", "symbols": ["heart", "spade", "diamond", "club"]}))
 
       assert @test_module.encodable?(schema, :heart)
     end


### PR DESCRIPTION
We will be adding a new function `encode_schema/1` in the near future

This is preparing for #48 