### PR TITLE
Remove the implementation for encodable?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 * `AvroEx.encode/2` now returns `{:error, AvroEx.EncodeError.t()}` in the case of an error
+* `AvroEx.encodeable?/2` implementation changed to use `AvroEx.encode/2` rather than a separate implementation
 
 ### Added
 * `AvroEx.encode!/2` - identical to `encode/2`, but raises

--- a/lib/avro_ex.ex
+++ b/lib/avro_ex.ex
@@ -24,10 +24,19 @@ defmodule AvroEx do
   @type encoded_avro :: binary
 
   @doc """
-  Checks to see if the given data is encodable using the given schema. Great in
-  unit tests.
+  Checks to see if the given data is encodable using the given schema.
+
+  Note that this function fully encodes the data to validate, and should
+  only be used in testing scenarios or in situations where performance is not
+  critical.
   """
-  defdelegate encodable?(schema, data), to: AvroEx.Schema
+  @spec encodable?(Schema.t(), term()) :: boolean()
+  def encodable?(schema, data) do
+    case encode(schema, data) do
+      {:ok, _encoded} -> true
+      {:error, _reason} -> false
+    end
+  end
 
   @spec parse_schema(Schema.json_schema()) ::
           {:ok, Schema.t()}

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -144,6 +144,7 @@ defmodule AvroEx.Encode do
   end
 
   defp do_encode(%Union{possibilities: possibilities} = schema, %Context{} = context, value) do
+    # TODO fix this?
     index =
       Enum.find_index(possibilities, fn possible_schema ->
         Schema.encodable?(possible_schema, context, value)

--- a/lib/avro_ex/schema/array.ex
+++ b/lib/avro_ex/schema/array.ex
@@ -2,7 +2,6 @@ defmodule AvroEx.Schema.Array do
   use Ecto.Schema
   require AvroEx.Schema.Macros, as: SchemaMacros
   alias AvroEx.{Schema, Term}
-  alias AvroEx.Schema.Context
   alias Ecto.Changeset
   import Ecto.Changeset
 
@@ -44,13 +43,4 @@ defmodule AvroEx.Schema.Array do
       {:error, reason} -> add_error(cs, :items, reason)
     end
   end
-
-  @spec match?(any(), any(), any()) :: boolean()
-  def match?(%__MODULE__{items: item_type}, %Context{} = context, data) when is_list(data) do
-    Enum.all?(data, fn item ->
-      Schema.encodable?(item_type, context, item)
-    end)
-  end
-
-  def match?(_array, _context, _data), do: false
 end

--- a/lib/avro_ex/schema/enum.ex
+++ b/lib/avro_ex/schema/enum.ex
@@ -6,7 +6,6 @@ defmodule AvroEx.Schema.Enum do
   import Ecto.Changeset
 
   alias AvroEx.Schema
-  alias AvroEx.Schema.Context
 
   @optional_fields [:aliases, :doc, :metadata, :namespace]
   @primary_key false
@@ -44,11 +43,4 @@ defmodule AvroEx.Schema.Enum do
     |> cast(params, @optional_fields ++ @required_fields)
     |> validate_required(@required_fields)
   end
-
-  @spec match?(any(), any(), any()) :: boolean()
-  def match?(%__MODULE__{symbols: symbols}, %Context{}, data) when is_binary(data) do
-    data in symbols
-  end
-
-  def match?(_enum, _context, _data), do: false
 end

--- a/lib/avro_ex/schema/fixed.ex
+++ b/lib/avro_ex/schema/fixed.ex
@@ -5,7 +5,6 @@ defmodule AvroEx.Schema.Fixed do
   import Ecto.Changeset
 
   alias AvroEx.Schema
-  alias AvroEx.Schema.Context
 
   embedded_schema do
     field(:aliases, {:array, :string}, default: [])
@@ -36,12 +35,4 @@ defmodule AvroEx.Schema.Fixed do
     |> cast(params, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
   end
-
-  @spec match?(t, Context.t(), term) :: boolean
-  def match?(%__MODULE__{size: size}, %Context{}, data)
-      when is_binary(data) and byte_size(data) == size do
-    true
-  end
-
-  def match?(_fixed, _context, _data), do: false
 end

--- a/lib/avro_ex/schema/map.ex
+++ b/lib/avro_ex/schema/map.ex
@@ -6,7 +6,6 @@ defmodule AvroEx.Schema.Map do
   import Ecto.Changeset
 
   alias AvroEx.{Schema, Term}
-  alias AvroEx.Schema.{Context, Primitive}
   alias Ecto.Changeset
 
   @primary_key false
@@ -46,14 +45,4 @@ defmodule AvroEx.Schema.Map do
       {:error, reason} -> add_error(cs, :values, reason)
     end
   end
-
-  @spec match?(any(), any(), any()) :: boolean()
-  def match?(%__MODULE__{values: value_type}, %Context{} = context, data) when is_map(data) do
-    Enum.all?(data, fn {key, value} ->
-      Schema.encodable?(%Primitive{type: :string}, context, key) and
-        Schema.encodable?(value_type, context, value)
-    end)
-  end
-
-  def match?(_map, _context, _data), do: false
 end

--- a/lib/avro_ex/schema/record.ex
+++ b/lib/avro_ex/schema/record.ex
@@ -5,7 +5,6 @@ defmodule AvroEx.Schema.Record do
   import Ecto.Changeset
   alias __MODULE__.Field
   alias AvroEx.{Schema}
-  alias AvroEx.Schema.Context
 
   embedded_schema do
     field(:aliases, {:array, :string}, default: [])
@@ -39,20 +38,4 @@ defmodule AvroEx.Schema.Record do
     |> validate_required(@required_fields)
     |> cast_embed(:fields)
   end
-
-  @spec match?(t, Context.t(), term) :: boolean
-  def match?(%__MODULE__{fields: fields}, %Context{} = context, data)
-      when is_map(data) and map_size(data) == length(fields) do
-    Enum.all?(fields, fn %Field{name: name} = field ->
-      data =
-        Map.new(data, fn
-          {k, v} when is_binary(k) -> {k, v}
-          {k, v} when is_atom(k) -> {to_string(k), v}
-        end)
-
-      Map.has_key?(data, name) and Schema.encodable?(field, context, data[name])
-    end)
-  end
-
-  def match?(_record, _context, _data), do: false
 end

--- a/lib/avro_ex/schema/record/field.ex
+++ b/lib/avro_ex/schema/record/field.ex
@@ -4,7 +4,6 @@ defmodule AvroEx.Schema.Record.Field do
 
   alias Ecto.Changeset
   alias AvroEx.{Schema, Term}
-  alias AvroEx.Schema.Context
 
   @type t() :: %__MODULE__{}
 
@@ -28,11 +27,6 @@ defmodule AvroEx.Schema.Record.Field do
     |> cast(params, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> encode_type
-  end
-
-  @spec match?(AvroEx.Schema.Record.Field.t(), AvroEx.Schema.Context.t(), any()) :: boolean()
-  def match?(%__MODULE__{type: type}, %Context{} = context, data) do
-    Schema.encodable?(type, context, data)
   end
 
   defp encode_type(%Changeset{} = cs) do

--- a/lib/avro_ex/schema/union.ex
+++ b/lib/avro_ex/schema/union.ex
@@ -3,7 +3,6 @@ defmodule AvroEx.Schema.Union do
   import Ecto.Changeset
 
   alias AvroEx.{Schema, Term}
-  alias AvroEx.Schema.Context
 
   @primary_key false
   @required_fields [:possibilities]
@@ -66,12 +65,5 @@ defmodule AvroEx.Schema.Union do
         add_error(cs, :possibilities, error)
       end)
     end
-  end
-
-  @spec match?(AvroEx.Schema.Union.t(), AvroEx.Schema.Context.t(), any()) :: boolean()
-  def match?(%__MODULE__{} = union, %Context{} = context, data) do
-    Enum.any?(union.possibilities, fn schema ->
-      Schema.encodable?(schema, context, data)
-    end)
   end
 end


### PR DESCRIPTION
Removes the implementation of `encodable?` and delegates to `encode/2` as mentioned in #58

Note that the thing I didn't realize is that unions are relying on this code in order to choose which encoder to use. I need to check how other implementations make this decision as incrementally attempting encoding is definitely not the most efficient path 