### PR TITLE
Add decode!/2 and add AvroEx.DecodeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Primitive null types now represented as `%Primitive{type: :null}` instead of `%Primitive{type: nil}`
 * Schema decoding now supports directly passing Elixir terms, will strictly validate the schema, and produce helpful error messages
 * Removed `Ecto` as a dependency
-* `AvroEx.full_name/2` - reverses the order of the arguments, accepting a Schema type or name, followed by the namespace
+* `AvroEx.Schema.full_name/2` - reverses the order of the arguments, accepting a Schema type or name, followed by the namespace
 
 ### Added
 * `AvroEx.encode!/2` - identical to `encode/2`, but returns raw value. Raises on error
@@ -16,7 +16,7 @@
 * `AvroEx.decode_schema/1` and `AvroEx.decode_schema!/` in place of `AvroEx.parse_schema/1`
 * Support for encoding and decoding `date` logical times to and from `Date.t()`
 * Schema decoding adds a `:strict` option that will strictly validate the schema for unrecognized fields
-* `AvroEx.encode_schema/2` - encode a `AvroEx.Schema.t()` back to JSON. Supports encoding the schema back to [Parsing Canonical Form](https://avro.apache.org/docs/current/spec.html#Parsing+Canonical+Form+for+Schemas)
+* `AvroEx.encode_schema/2` - encode a `AvroEx.Schema.t()` back to JSON. Supports encoding the schema to [Parsing Canonical Form](https://avro.apache.org/docs/current/spec.html#Parsing+Canonical+Form+for+Schemas)
 * `AvroEx.Schema.namespace/2` - Returns the namespace of the given Schema type
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 * `AvroEx.full_name/2` - reverses the order of the arguments, accepting a Schema type or name, followed by the namespace
 
 ### Added
-* `AvroEx.encode!/2` - identical to `encode/2`, but raises
+* `AvroEx.encode!/2` - identical to `encode/2`, but returns raw value. Raises on error
+* `AvroEx.decode!/2` - identical to `decode/2`, but returns raw value. Raises on error
 * `AvroEx.decode_schema/1` and `AvroEx.decode_schema!/` in place of `AvroEx.parse_schema/1`
 * Support for encoding and decoding `date` logical times to and from `Date.t()`
 * Schema decoding adds a `:strict` option that will strictly validate the schema for unrecognized fields

--- a/lib/avro_ex.ex
+++ b/lib/avro_ex.ex
@@ -129,7 +129,9 @@ defmodule AvroEx do
   end
 
   @doc """
-  Same as `encode/2`, but returns the encoded value directly and raises on errors
+  Same as `encode/2`, but returns the encoded value directly.
+
+  Raises `t:AvroEx.EncodeError.t/0` on error.
 
   ## Examples
 
@@ -157,7 +159,29 @@ defmodule AvroEx do
           {:ok, term}
           | {:error, term()}
   def decode(schema, message) do
-    AvroEx.Decode.decode(schema, message)
+    case AvroEx.Decode.decode(schema, message) do
+      {:ok, value, _} -> {:ok, value}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  @doc """
+  Same as decode/2, but returns raw decoded value.
+
+  Raises `t:AvroEx.DecodeError.t/0` on error.
+
+  ## Examples
+
+      iex> schema = AvroEx.decode_schema!("string")
+      iex> encoded = AvroEx.encode!(schema, "hello")
+      iex> AvroEx.decode!(schema, encoded)
+      "hello"
+  """
+  def decode!(schema, message) do
+    case AvroEx.Decode.decode(schema, message) do
+      {:ok, value, _} -> value
+      {:error, error} -> raise error
+    end
   end
 
   @deprecated "Use AvroEx.Schema.Context.lookup/2"

--- a/lib/avro_ex.ex
+++ b/lib/avro_ex.ex
@@ -157,7 +157,7 @@ defmodule AvroEx do
   """
   @spec decode(Schema.t(), encoded_avro) ::
           {:ok, term}
-          | {:error, term()}
+          | {:error, AvroEx.DecodeError.t()}
   def decode(schema, message) do
     case AvroEx.Decode.decode(schema, message) do
       {:ok, value, _} -> {:ok, value}
@@ -177,6 +177,7 @@ defmodule AvroEx do
       iex> AvroEx.decode!(schema, encoded)
       "hello"
   """
+  @spec decode!(Schema.t(), encoded_avro()) :: term()
   def decode!(schema, message) do
     case AvroEx.Decode.decode(schema, message) do
       {:ok, value, _} -> value

--- a/lib/avro_ex/decode.ex
+++ b/lib/avro_ex/decode.ex
@@ -2,7 +2,7 @@ defmodule AvroEx.Decode do
   @moduledoc false
 
   require Bitwise
-  alias AvroEx.DecodeError
+  alias AvroEx.{DecodeError}
   alias AvroEx.Schema
   alias AvroEx.Schema.{Array, Context, Fixed, Primitive, Record, Reference, Union}
   alias AvroEx.Schema.Record.Field

--- a/lib/avro_ex/decode_error.ex
+++ b/lib/avro_ex/decode_error.ex
@@ -1,0 +1,15 @@
+defmodule AvroEx.DecodeError do
+  @moduledoc """
+  Exceptions in decoding Avro data
+  """
+
+  defexception [:message]
+
+  @type t :: %__MODULE__{}
+
+  @spec new(tuple()) :: t()
+  def new({:invalid_string, str}) do
+    message = "Invalid UTF-8 string found #{inspect(str)}."
+    %__MODULE__{message: message}
+  end
+end

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -86,7 +86,7 @@ defmodule AvroEx.Decode.Test do
       {:ok, schema} = AvroEx.decode_schema(~S("string"))
       {:ok, bytes} = AvroEx.encode(schema, "Hello there 🕶")
 
-      assert {:ok, "Hello there 🕶"} =  AvroEx.decode(schema, bytes)
+      assert {:ok, "Hello there 🕶"} = AvroEx.decode(schema, bytes)
     end
   end
 

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -1,13 +1,13 @@
 defmodule AvroEx.Decode.Test do
   use ExUnit.Case, async: true
 
-  @test_module AvroEx.Decode
+  alias AvroEx.DecodeError
 
   describe "decode (primitive)" do
     test "null" do
       {:ok, schema} = AvroEx.decode_schema(~S("null"))
       {:ok, avro_message} = AvroEx.encode(schema, nil)
-      assert {:ok, nil} = @test_module.decode(schema, avro_message)
+      assert {:ok, nil} = AvroEx.decode(schema, avro_message)
     end
 
     test "boolean" do
@@ -15,8 +15,8 @@ defmodule AvroEx.Decode.Test do
       {:ok, true_message} = AvroEx.encode(schema, true)
       {:ok, false_message} = AvroEx.encode(schema, false)
 
-      assert {:ok, true} = @test_module.decode(schema, true_message)
-      assert {:ok, false} = @test_module.decode(schema, false_message)
+      assert {:ok, true} = AvroEx.decode(schema, true_message)
+      assert {:ok, false} = AvroEx.decode(schema, false_message)
     end
 
     test "integer" do
@@ -29,13 +29,13 @@ defmodule AvroEx.Decode.Test do
       {:ok, min_int32} = AvroEx.encode(schema, -2_147_483_648)
       {:ok, max_int32} = AvroEx.encode(schema, 2_147_483_647)
 
-      assert {:ok, 0} = @test_module.decode(schema, zero)
-      assert {:ok, -10} = @test_module.decode(schema, neg_ten)
-      assert {:ok, 10} = @test_module.decode(schema, ten)
-      assert {:ok, 5_000_000} = @test_module.decode(schema, big)
-      assert {:ok, -5_000_000} = @test_module.decode(schema, small)
-      assert {:ok, -2_147_483_648} = @test_module.decode(schema, min_int32)
-      assert {:ok, 2_147_483_647} = @test_module.decode(schema, max_int32)
+      assert {:ok, 0} = AvroEx.decode(schema, zero)
+      assert {:ok, -10} = AvroEx.decode(schema, neg_ten)
+      assert {:ok, 10} = AvroEx.decode(schema, ten)
+      assert {:ok, 5_000_000} = AvroEx.decode(schema, big)
+      assert {:ok, -5_000_000} = AvroEx.decode(schema, small)
+      assert {:ok, -2_147_483_648} = AvroEx.decode(schema, min_int32)
+      assert {:ok, 2_147_483_647} = AvroEx.decode(schema, max_int32)
     end
 
     test "long" do
@@ -48,13 +48,13 @@ defmodule AvroEx.Decode.Test do
       {:ok, min_int64} = AvroEx.encode(schema, -9_223_372_036_854_775_808)
       {:ok, max_int64} = AvroEx.encode(schema, 9_223_372_036_854_775_807)
 
-      assert {:ok, 0} = @test_module.decode(schema, zero)
-      assert {:ok, -10} = @test_module.decode(schema, neg_ten)
-      assert {:ok, 10} = @test_module.decode(schema, ten)
-      assert {:ok, 2_147_483_647} = @test_module.decode(schema, big)
-      assert {:ok, -2_147_483_647} = @test_module.decode(schema, small)
-      assert {:ok, -9_223_372_036_854_775_808} = @test_module.decode(schema, min_int64)
-      assert {:ok, 9_223_372_036_854_775_807} = @test_module.decode(schema, max_int64)
+      assert {:ok, 0} = AvroEx.decode(schema, zero)
+      assert {:ok, -10} = AvroEx.decode(schema, neg_ten)
+      assert {:ok, 10} = AvroEx.decode(schema, ten)
+      assert {:ok, 2_147_483_647} = AvroEx.decode(schema, big)
+      assert {:ok, -2_147_483_647} = AvroEx.decode(schema, small)
+      assert {:ok, -9_223_372_036_854_775_808} = AvroEx.decode(schema, min_int64)
+      assert {:ok, 9_223_372_036_854_775_807} = AvroEx.decode(schema, max_int64)
     end
 
     test "float" do
@@ -62,8 +62,8 @@ defmodule AvroEx.Decode.Test do
       {:ok, zero} = AvroEx.encode(schema, 0.0)
       {:ok, big} = AvroEx.encode(schema, 256.25)
 
-      assert {:ok, 0.0} = @test_module.decode(schema, zero)
-      assert {:ok, 256.25} = @test_module.decode(schema, big)
+      assert {:ok, 0.0} = AvroEx.decode(schema, zero)
+      assert {:ok, 256.25} = AvroEx.decode(schema, big)
     end
 
     test "double" do
@@ -71,22 +71,22 @@ defmodule AvroEx.Decode.Test do
       {:ok, zero} = AvroEx.encode(schema, 0.0)
       {:ok, big} = AvroEx.encode(schema, 256.25)
 
-      assert {:ok, 0.0} = @test_module.decode(schema, zero)
-      assert {:ok, 256.25} = @test_module.decode(schema, big)
+      assert {:ok, 0.0} = AvroEx.decode(schema, zero)
+      assert {:ok, 256.25} = AvroEx.decode(schema, big)
     end
 
     test "bytes" do
       {:ok, schema} = AvroEx.decode_schema(~S("bytes"))
       {:ok, bytes} = AvroEx.encode(schema, <<222, 213, 194, 34, 58, 92, 95, 62>>)
 
-      assert {:ok, <<222, 213, 194, 34, 58, 92, 95, 62>>} = @test_module.decode(schema, bytes)
+      assert {:ok, <<222, 213, 194, 34, 58, 92, 95, 62>>} = AvroEx.decode(schema, bytes)
     end
 
     test "string" do
       {:ok, schema} = AvroEx.decode_schema(~S("string"))
       {:ok, bytes} = AvroEx.encode(schema, "Hello there 🕶")
 
-      assert {:ok, "Hello there 🕶"} = @test_module.decode(schema, bytes)
+      assert {:ok, "Hello there 🕶"} =  AvroEx.decode(schema, bytes)
     end
   end
 
@@ -100,7 +100,7 @@ defmodule AvroEx.Decode.Test do
 
       {:ok, encoded_message} = AvroEx.encode(schema, %{"a" => 1, "b" => 2, "e" => "Hello world!"})
 
-      assert {:ok, %{"a" => 1, "b" => 2, "e" => "Hello world!"}} = @test_module.decode(schema, encoded_message)
+      assert {:ok, %{"a" => 1, "b" => 2, "e" => "Hello world!"}} = AvroEx.decode(schema, encoded_message)
     end
 
     test "union" do
@@ -109,8 +109,8 @@ defmodule AvroEx.Decode.Test do
       {:ok, encoded_null} = AvroEx.encode(schema, nil)
       {:ok, encoded_int} = AvroEx.encode(schema, 25)
 
-      assert {:ok, nil} = @test_module.decode(schema, encoded_null)
-      assert {:ok, 25} = @test_module.decode(schema, encoded_int)
+      assert {:ok, nil} = AvroEx.decode(schema, encoded_null)
+      assert {:ok, 25} = AvroEx.decode(schema, encoded_int)
     end
 
     test "union with DateTime" do
@@ -120,8 +120,8 @@ defmodule AvroEx.Decode.Test do
       {:ok, encoded_null} = AvroEx.encode(schema, nil)
       {:ok, encoded_datetime} = AvroEx.encode(schema, datetime)
 
-      assert {:ok, nil} = @test_module.decode(schema, encoded_null)
-      assert {:ok, ^datetime} = @test_module.decode(schema, encoded_datetime)
+      assert {:ok, nil} = AvroEx.decode(schema, encoded_null)
+      assert {:ok, ^datetime} = AvroEx.decode(schema, encoded_datetime)
     end
 
     test "union with Time" do
@@ -131,8 +131,8 @@ defmodule AvroEx.Decode.Test do
       {:ok, encoded_null} = AvroEx.encode(schema, nil)
       {:ok, encoded_time} = AvroEx.encode(schema, time)
 
-      assert {:ok, nil} = @test_module.decode(schema, encoded_null)
-      assert {:ok, ^time} = @test_module.decode(schema, encoded_time)
+      assert {:ok, nil} = AvroEx.decode(schema, encoded_null)
+      assert {:ok, ^time} = AvroEx.decode(schema, encoded_time)
     end
 
     test "array" do
@@ -140,7 +140,7 @@ defmodule AvroEx.Decode.Test do
 
       {:ok, encoded_array} = AvroEx.encode(schema, [1, 2, 3, nil, 4, 5, nil])
 
-      assert {:ok, [1, 2, 3, nil, 4, 5, nil]} = @test_module.decode(schema, encoded_array)
+      assert {:ok, [1, 2, 3, nil, 4, 5, nil]} = AvroEx.decode(schema, encoded_array)
     end
 
     test "empty array" do
@@ -148,7 +148,7 @@ defmodule AvroEx.Decode.Test do
 
       {:ok, encoded_array} = AvroEx.encode(schema, [])
 
-      assert {:ok, []} = @test_module.decode(schema, encoded_array)
+      assert {:ok, []} = AvroEx.decode(schema, encoded_array)
     end
 
     test "map" do
@@ -156,7 +156,7 @@ defmodule AvroEx.Decode.Test do
 
       {:ok, encoded_array} = AvroEx.encode(schema, %{"a" => 1, "b" => nil, "c" => 3})
 
-      assert {:ok, %{"a" => 1, "b" => nil, "c" => 3}} = @test_module.decode(schema, encoded_array)
+      assert {:ok, %{"a" => 1, "b" => nil, "c" => 3}} = AvroEx.decode(schema, encoded_array)
     end
 
     test "empty map" do
@@ -164,7 +164,7 @@ defmodule AvroEx.Decode.Test do
 
       {:ok, encoded_map} = AvroEx.encode(schema, %{})
 
-      assert {:ok, %{}} = @test_module.decode(schema, encoded_map)
+      assert {:ok, %{}} = AvroEx.decode(schema, encoded_map)
     end
 
     test "enum" do
@@ -176,17 +176,17 @@ defmodule AvroEx.Decode.Test do
       {:ok, diamond} = AvroEx.encode(schema, "diamond")
       {:ok, spade} = AvroEx.encode(schema, "spade")
 
-      assert {:ok, "club"} = @test_module.decode(schema, club)
-      assert {:ok, "heart"} = @test_module.decode(schema, heart)
-      assert {:ok, "diamond"} = @test_module.decode(schema, diamond)
-      assert {:ok, "spade"} = @test_module.decode(schema, spade)
+      assert {:ok, "club"} = AvroEx.decode(schema, club)
+      assert {:ok, "heart"} = AvroEx.decode(schema, heart)
+      assert {:ok, "diamond"} = AvroEx.decode(schema, diamond)
+      assert {:ok, "spade"} = AvroEx.decode(schema, spade)
     end
 
     test "fixed" do
       {:ok, schema} = AvroEx.decode_schema(~S({"type": "fixed", "name": "SHA", "size": 40}))
       sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       {:ok, encoded_sha} = AvroEx.encode(schema, sha)
-      assert {:ok, ^sha} = @test_module.decode(schema, encoded_sha)
+      assert {:ok, ^sha} = AvroEx.decode(schema, encoded_sha)
     end
 
     test "record with empty array of records" do
@@ -221,7 +221,7 @@ defmodule AvroEx.Decode.Test do
 
       {:ok, encoded} = AvroEx.encode(schema, %{"friends" => [], "username" => "iamauser"})
 
-      assert {:ok, %{"friends" => [], "username" => "iamauser"}} = @test_module.decode(schema, encoded)
+      assert {:ok, %{"friends" => [], "username" => "iamauser"}} = AvroEx.decode(schema, encoded)
     end
   end
 
@@ -244,7 +244,7 @@ defmodule AvroEx.Decode.Test do
       {:ok, micro_schema} = AvroEx.decode_schema(~S({"type": "long", "logicalType":"timestamp-micros"}))
 
       {:ok, micro_encode} = AvroEx.encode(micro_schema, now)
-      assert {:ok, ^now} = @test_module.decode(micro_schema, micro_encode)
+      assert {:ok, ^now} = AvroEx.decode(micro_schema, micro_encode)
     end
 
     test "datetime millis" do
@@ -253,7 +253,7 @@ defmodule AvroEx.Decode.Test do
       {:ok, milli_schema} = AvroEx.decode_schema(~S({"type": "long", "logicalType":"timestamp-millis"}))
 
       {:ok, milli_encode} = AvroEx.encode(milli_schema, now)
-      assert {:ok, ^now} = @test_module.decode(milli_schema, milli_encode)
+      assert {:ok, ^now} = AvroEx.decode(milli_schema, milli_encode)
     end
 
     test "datetime nanos" do
@@ -262,7 +262,7 @@ defmodule AvroEx.Decode.Test do
       {:ok, nano_schema} = AvroEx.decode_schema(~S({"type": "long", "logicalType":"timestamp-nanos"}))
 
       {:ok, nano_encode} = AvroEx.encode(nano_schema, now)
-      assert {:ok, ^now} = @test_module.decode(nano_schema, nano_encode)
+      assert {:ok, ^now} = AvroEx.decode(nano_schema, nano_encode)
     end
 
     test "time micros" do
@@ -270,7 +270,7 @@ defmodule AvroEx.Decode.Test do
 
       {:ok, micro_schema} = AvroEx.decode_schema(~S({"type": "long", "logicalType":"time-micros"}))
       {:ok, micro_encode} = AvroEx.encode(micro_schema, now)
-      assert {:ok, ^now} = @test_module.decode(micro_schema, micro_encode)
+      assert {:ok, ^now} = AvroEx.decode(micro_schema, micro_encode)
     end
 
     test "time millis" do
@@ -278,9 +278,19 @@ defmodule AvroEx.Decode.Test do
 
       {:ok, milli_schema} = AvroEx.decode_schema(~S({"type": "int", "logicalType":"time-millis"}))
       {:ok, milli_encode} = AvroEx.encode(milli_schema, now)
-      {:ok, time} = @test_module.decode(milli_schema, milli_encode)
+      {:ok, time} = AvroEx.decode(milli_schema, milli_encode)
 
       assert Time.truncate(time, :millisecond) == now
+    end
+  end
+
+  describe "DecodingError" do
+    test "invalid utf string" do
+      assert schema = AvroEx.decode_schema!("string")
+
+      assert_raise DecodeError, "Invalid UTF-8 string found <<104, 101, 108, 108, 255>>.", fn ->
+        AvroEx.decode!(schema, <<"\nhell", 0xFFFF::16>>)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #50 

Adds a new function and changes the function signature of decode such that it returns an error. Note that there is a lot more work to be done to improve the quality of decoding messages. I am going to punt that to post 2.0 so that we can get this release out.