### PR TITLE
Implement tagged unions for named fields

### DIFF
--- a/lib/avro_ex.ex
+++ b/lib/avro_ex.ex
@@ -155,11 +155,11 @@ defmodule AvroEx do
       {:ok, true}
 
   """
-  @spec decode(Schema.t(), encoded_avro) ::
+  @spec decode(Schema.t(), encoded_avro, keyword()) ::
           {:ok, term}
           | {:error, AvroEx.DecodeError.t()}
-  def decode(schema, message) do
-    case AvroEx.Decode.decode(schema, message) do
+  def decode(schema, message, opts \\ []) do
+    case AvroEx.Decode.decode(schema, message, opts) do
       {:ok, value, _} -> {:ok, value}
       {:error, error} -> {:error, error}
     end

--- a/lib/avro_ex.ex
+++ b/lib/avro_ex.ex
@@ -121,6 +121,14 @@ defmodule AvroEx do
       iex> schema = AvroEx.decode_schema!("int")
       iex> AvroEx.encode(schema, 1234)
       {:ok, <<164, 19>>}
+
+  ## Tagged unions
+
+  When supplying a union value one can optionally supply a tagged tuple of `{name, value}`
+  instead of just the plain `value` to force encoding the value as the named type
+  found using `name` instead of matching by the shape of `value`. This can improve
+  performance and allows forcing a selected named type even if the shape of the
+  data is the same. See also the "Tagged unions" section on `decode/3`.
   """
   @spec encode(Schema.t(), term) ::
           {:ok, encoded_avro} | {:error, AvroEx.EncodeError.t() | Exception.t()}
@@ -154,6 +162,12 @@ defmodule AvroEx do
       iex> AvroEx.decode(schema, <<1>>)
       {:ok, true}
 
+  ## Tagged unions
+
+  When decoding one can set the option `tagged_unions: true` to decode union
+  values as a tagged tuple of `{name, value}` instead of just the plain `value`.
+  This allows to retain the information about which union schema was used for
+  encoding when this cannot be infered from the `value` alone.
   """
   @spec decode(Schema.t(), encoded_avro, keyword()) ::
           {:ok, term}

--- a/lib/avro_ex/decode.ex
+++ b/lib/avro_ex/decode.ex
@@ -12,34 +12,34 @@ defmodule AvroEx.Decode do
   @seconds_in_day 24 * 60 * 60
 
   @doc false
-  @spec decode(AvroEx.Schema.t(), binary()) :: {:ok, any(), binary()} | {:error, AvroEx.DecodeError.t()}
-  def decode(%Schema{schema: schema, context: context}, avro_message)
+  @spec decode(AvroEx.Schema.t(), binary(), keyword()) :: {:ok, any(), binary()} | {:error, AvroEx.DecodeError.t()}
+  def decode(%Schema{schema: schema, context: context}, avro_message, opts \\ [])
       when is_binary(avro_message) do
     try do
-      {value, rest} = do_decode(schema, context, avro_message)
+      {value, rest} = do_decode(schema, context, avro_message, opts)
       {:ok, value, rest}
     catch
       :throw, %DecodeError{} = e -> {:error, e}
     end
   end
 
-  defp do_decode(%Reference{type: name}, %Context{} = context, data) do
-    do_decode(Context.lookup(context, name), context, data)
+  defp do_decode(%Reference{type: name}, %Context{} = context, data, opts) do
+    do_decode(Context.lookup(context, name), context, data, opts)
   end
 
-  defp do_decode(%Primitive{type: :null}, %Context{}, data) when is_binary(data) do
+  defp do_decode(%Primitive{type: :null}, %Context{}, data, _) when is_binary(data) do
     {nil, data}
   end
 
-  defp do_decode(%Primitive{type: :boolean}, %Context{}, <<0::8, rest::binary>>) do
+  defp do_decode(%Primitive{type: :boolean}, %Context{}, <<0::8, rest::binary>>, _) do
     {false, rest}
   end
 
-  defp do_decode(%Primitive{type: :boolean}, %Context{}, <<1::8, rest::binary>>) do
+  defp do_decode(%Primitive{type: :boolean}, %Context{}, <<1::8, rest::binary>>, _) do
     {true, rest}
   end
 
-  defp do_decode(%Primitive{type: :int, metadata: %{"logicalType" => "date"}}, %Context{}, data) do
+  defp do_decode(%Primitive{type: :int, metadata: %{"logicalType" => "date"}}, %Context{}, data, _) do
     {val, rest} = variable_integer_decode(data, 0, 0, 32)
 
     {:ok, datetime} = DateTime.from_unix(@seconds_in_day * zigzag_decode(val))
@@ -51,7 +51,8 @@ defmodule AvroEx.Decode do
   defp do_decode(
          %Primitive{type: :int, metadata: %{"logicalType" => "time-millis"}},
          %Context{},
-         data
+         data,
+         _
        )
        when is_binary(data) do
     {val, rest} = variable_integer_decode(data, 0, 0, 32)
@@ -63,7 +64,7 @@ defmodule AvroEx.Decode do
     {time, rest}
   end
 
-  defp do_decode(%Primitive{type: :int}, %Context{}, data) when is_binary(data) do
+  defp do_decode(%Primitive{type: :int}, %Context{}, data, _) when is_binary(data) do
     {val, rest} = variable_integer_decode(data, 0, 0, 32)
     {zigzag_decode(val), rest}
   end
@@ -71,7 +72,8 @@ defmodule AvroEx.Decode do
   defp do_decode(
          %Primitive{type: :long, metadata: %{"logicalType" => "time-micros"}},
          %Context{},
-         data
+         data,
+         _
        )
        when is_binary(data) do
     {val, rest} = variable_integer_decode(data, 0, 0, 64)
@@ -86,7 +88,8 @@ defmodule AvroEx.Decode do
   defp do_decode(
          %Primitive{type: :long, metadata: %{"logicalType" => "timestamp-nanos"}},
          %Context{},
-         data
+         data,
+         _
        )
        when is_binary(data) do
     {val, rest} = variable_integer_decode(data, 0, 0, 64)
@@ -98,7 +101,8 @@ defmodule AvroEx.Decode do
   defp do_decode(
          %Primitive{type: :long, metadata: %{"logicalType" => "timestamp-micros"}},
          %Context{},
-         data
+         data,
+         _
        )
        when is_binary(data) do
     {val, rest} = variable_integer_decode(data, 0, 0, 64)
@@ -110,7 +114,8 @@ defmodule AvroEx.Decode do
   defp do_decode(
          %Primitive{type: :long, metadata: %{"logicalType" => "timestamp-millis"}},
          %Context{},
-         data
+         data,
+         _
        )
        when is_binary(data) do
     {val, rest} = variable_integer_decode(data, 0, 0, 64)
@@ -119,23 +124,23 @@ defmodule AvroEx.Decode do
     {date_time, rest}
   end
 
-  defp do_decode(%Primitive{type: :long}, %Context{}, data) when is_binary(data) do
+  defp do_decode(%Primitive{type: :long}, %Context{}, data, _) when is_binary(data) do
     {val, rest} = variable_integer_decode(data, 0, 0, 64)
     {zigzag_decode(val), rest}
   end
 
-  defp do_decode(%Primitive{type: :float}, %Context{}, data) when is_binary(data) do
+  defp do_decode(%Primitive{type: :float}, %Context{}, data, _) when is_binary(data) do
     <<float::little-float-size(32), rest::binary>> = data
     {float, rest}
   end
 
-  defp do_decode(%Primitive{type: :double}, %Context{}, data) when is_binary(data) do
+  defp do_decode(%Primitive{type: :double}, %Context{}, data, _) when is_binary(data) do
     <<float::little-float-size(64), rest::binary>> = data
     {float, rest}
   end
 
-  defp do_decode(%Primitive{type: :bytes}, %Context{} = context, data) when is_binary(data) do
-    {byte_count, buffer} = do_decode(%Primitive{type: :long}, context, data)
+  defp do_decode(%Primitive{type: :bytes}, %Context{} = context, data, opts) when is_binary(data) do
+    {byte_count, buffer} = do_decode(%Primitive{type: :long}, context, data, opts)
     bit_count = byte_count * 8
 
     <<bytes::bitstring-size(bit_count), rest::binary>> = buffer
@@ -143,8 +148,8 @@ defmodule AvroEx.Decode do
     {bytes, rest}
   end
 
-  defp do_decode(%Primitive{type: :string}, %Context{} = context, data) when is_binary(data) do
-    {str, rest} = do_decode(%Primitive{type: :bytes}, context, data)
+  defp do_decode(%Primitive{type: :string}, %Context{} = context, data, opts) when is_binary(data) do
+    {str, rest} = do_decode(%Primitive{type: :bytes}, context, data, opts)
 
     if String.valid?(str) do
       {str, rest}
@@ -153,10 +158,10 @@ defmodule AvroEx.Decode do
     end
   end
 
-  defp do_decode(%Record{} = record, %Context{} = context, data) when is_binary(data) do
+  defp do_decode(%Record{} = record, %Context{} = context, data, opts) when is_binary(data) do
     {decoded, buffer} =
       Enum.reduce(record.fields, {[], data}, fn field, {decoded, buffer} ->
-        {val, buff} = do_decode(field, context, buffer)
+        {val, buff} = do_decode(field, context, buffer, opts)
         {[val | decoded], buff}
       end)
 
@@ -172,25 +177,31 @@ defmodule AvroEx.Decode do
     {decoded_map, buffer}
   end
 
-  defp do_decode(%Field{type: type}, %Context{} = context, data) when is_binary(data) do
-    do_decode(type, context, data)
+  defp do_decode(%Field{type: type}, %Context{} = context, data, opts) when is_binary(data) do
+    do_decode(type, context, data, opts)
   end
 
-  defp do_decode(%Union{possibilities: possibilities}, %Context{} = context, data)
+  defp do_decode(%Union{possibilities: possibilities}, %Context{} = context, data, opts)
        when is_binary(data) do
-    {index, rest} = do_decode(%Primitive{type: :long}, context, data)
+    {index, rest} = do_decode(%Primitive{type: :long}, context, data, opts)
     schema = :lists.nth(index + 1, possibilities)
 
-    do_decode(schema, context, rest)
+    {decoded_item, rest} = do_decode(schema, context, rest, opts)
+
+    if Keyword.get(opts, :tagged_unions, false) && Map.has_key?(schema, :name) do
+      {{schema.name, decoded_item}, rest}
+    else
+      {decoded_item, rest}
+    end
   end
 
-  defp do_decode(%Array{items: item_schema}, %Context{} = context, data) when is_binary(data) do
-    {count, buffer} = do_decode(%Primitive{type: :long}, context, data)
+  defp do_decode(%Array{items: item_schema}, %Context{} = context, data, opts) when is_binary(data) do
+    {count, buffer} = do_decode(%Primitive{type: :long}, context, data, opts)
 
     if count > 0 do
       {decoded_items, rest} =
         Enum.reduce(1..count, {[], buffer}, fn _, {decoded_items, buffer} ->
-          {decoded_item, buffer} = do_decode(item_schema, context, buffer)
+          {decoded_item, buffer} = do_decode(item_schema, context, buffer, opts)
           {[decoded_item | decoded_items], buffer}
         end)
 
@@ -200,15 +211,15 @@ defmodule AvroEx.Decode do
     end
   end
 
-  defp do_decode(%AvroEx.Schema.Map{values: value_schema}, %Context{} = context, data) when is_binary(data) do
-    {count, buffer} = do_decode(%Primitive{type: :long}, context, data)
+  defp do_decode(%AvroEx.Schema.Map{values: value_schema}, %Context{} = context, data, opts) when is_binary(data) do
+    {count, buffer} = do_decode(%Primitive{type: :long}, context, data, opts)
     string_schema = %Primitive{type: :string}
 
     if count > 0 do
       {decoded_values, rest} =
         Enum.reduce(1..count, {[], buffer}, fn _, {decoded_values, buffer} ->
-          {decoded_key, buffer} = do_decode(string_schema, context, buffer)
-          {decoded_value, buffer} = do_decode(value_schema, context, buffer)
+          {decoded_key, buffer} = do_decode(string_schema, context, buffer, opts)
+          {decoded_value, buffer} = do_decode(value_schema, context, buffer, opts)
           {[{decoded_key, decoded_value} | decoded_values], buffer}
         end)
 
@@ -218,12 +229,12 @@ defmodule AvroEx.Decode do
     end
   end
 
-  defp do_decode(%AvroEx.Schema.Enum{symbols: symbols}, %Context{} = context, data) when is_binary(data) do
-    {index, rest} = do_decode(%Primitive{type: :long}, context, data)
+  defp do_decode(%AvroEx.Schema.Enum{symbols: symbols}, %Context{} = context, data, opts) when is_binary(data) do
+    {index, rest} = do_decode(%Primitive{type: :long}, context, data, opts)
     {:lists.nth(index + 1, symbols), rest}
   end
 
-  defp do_decode(%Fixed{size: size}, %Context{}, data) when is_binary(data) do
+  defp do_decode(%Fixed{size: size}, %Context{}, data, _) when is_binary(data) do
     <<fixed::binary-size(size), rest::binary>> = data
     {fixed, rest}
   end

--- a/lib/avro_ex/decode.ex
+++ b/lib/avro_ex/decode.ex
@@ -188,7 +188,7 @@ defmodule AvroEx.Decode do
 
     {decoded_item, rest} = do_decode(schema, context, rest, opts)
 
-    if Keyword.get(opts, :tagged_unions, false) && Map.has_key?(schema, :name) do
+    if Keyword.get(opts, :tagged_unions, false) and Map.has_key?(schema, :name) do
       {{schema.name, decoded_item}, rest}
     else
       {decoded_item, rest}

--- a/lib/avro_ex/decode.ex
+++ b/lib/avro_ex/decode.ex
@@ -183,10 +183,10 @@ defmodule AvroEx.Decode do
 
   defp do_decode(%Union{possibilities: possibilities}, %Context{} = context, data, opts)
        when is_binary(data) do
-    {index, rest} = do_decode(%Primitive{type: :long}, context, data, opts)
+    {index, index_rest} = do_decode(%Primitive{type: :long}, context, data, opts)
     schema = :lists.nth(index + 1, possibilities)
 
-    {decoded_item, rest} = do_decode(schema, context, rest, opts)
+    {decoded_item, rest} = do_decode(schema, context, index_rest, opts)
 
     if Keyword.get(opts, :tagged_unions, false) and Map.has_key?(schema, :name) do
       {{schema.name, decoded_item}, rest}

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -135,6 +135,31 @@ defmodule AvroEx.Decode.Test do
       assert {:ok, ^time} = AvroEx.decode(schema, encoded_time)
     end
 
+    test "decode tagged named possibility" do
+      record_json_factory = fn name ->
+        ~s"""
+          {
+            "type": "record",
+            "name": "#{name}",
+            "fields": [
+              {"type": "string", "name": "value"}
+            ]
+          }
+        """
+      end
+
+      {:ok, schema} = AvroEx.decode_schema(~s([#{record_json_factory.("a")}, #{record_json_factory.("b")}]))
+
+      {:ok, encoded_a} = AvroEx.encode(schema, {"a", %{"value" => "hello"}})
+      {:ok, encoded_b} = AvroEx.encode(schema, {"b", %{"value" => "hello"}})
+
+      assert {:ok, %{"value" => "hello"}} = AvroEx.decode(schema, encoded_a)
+      assert {:ok, %{"value" => "hello"}} = AvroEx.decode(schema, encoded_b)
+
+      assert {:ok, {"a", %{"value" => "hello"}}} = AvroEx.decode(schema, encoded_a, tagged_unions: true)
+      assert {:ok, {"b", %{"value" => "hello"}}} = AvroEx.decode(schema, encoded_b, tagged_unions: true)
+    end
+
     test "array" do
       {:ok, schema} = AvroEx.decode_schema(~S({"type": "array", "items": ["null", "int"]}))
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -285,6 +285,32 @@ defmodule AvroEx.Encode.Test do
       assert encoded_union == index <> encoded_record
     end
 
+    test "works as expected with union values tagged for a named possibility" do
+      record_json_factory = fn name ->
+        ~s"""
+          {
+            "type": "record",
+            "name": "#{name}",
+            "fields": [
+              {"type": "string", "name": "value"}
+            ]
+          }
+        """
+      end
+
+      json_schema = ~s([#{record_json_factory.("a")}, #{record_json_factory.("b")}])
+
+      {:ok, schema} = AvroEx.decode_schema(json_schema)
+      {:ok, int_schema} = AvroEx.decode_schema(~S("int"))
+      {:ok, record_schema} = AvroEx.decode_schema(record_json_factory.("b"))
+
+      {:ok, index} = @test_module.encode(int_schema, 1)
+      {:ok, encoded_record} = @test_module.encode(record_schema, %{"value" => "hello"})
+      {:ok, encoded_union} = @test_module.encode(schema, {"b", %{"value" => "hello"}})
+
+      assert encoded_union == index <> encoded_record
+    end
+
     test "errors if the data doesn't match the schema" do
       {:ok, schema} = AvroEx.decode_schema(~S(["null", "int"]))
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -308,6 +308,12 @@ defmodule AvroEx.Encode.Test do
       {:ok, encoded_record} = @test_module.encode(record_schema, %{"value" => "hello"})
       {:ok, encoded_union} = @test_module.encode(schema, {"b", %{"value" => "hello"}})
 
+      {:error,
+       %AvroEx.EncodeError{
+         message:
+           "Schema Mismatch: Expected value of Union<possibilities=Record<name=a>|Record<name=b>>, got {\"c\", %{\"value\" => \"hello\"}}"
+       }} = @test_module.encode(schema, {"c", %{"value" => "hello"}})
+
       assert encoded_union == index <> encoded_record
     end
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -308,13 +308,32 @@ defmodule AvroEx.Encode.Test do
       {:ok, encoded_record} = @test_module.encode(record_schema, %{"value" => "hello"})
       {:ok, encoded_union} = @test_module.encode(schema, {"b", %{"value" => "hello"}})
 
-      {:error,
-       %AvroEx.EncodeError{
-         message:
-           "Schema Mismatch: Expected value of Union<possibilities=Record<name=a>|Record<name=b>>, got {\"c\", %{\"value\" => \"hello\"}}"
-       }} = @test_module.encode(schema, {"c", %{"value" => "hello"}})
-
       assert encoded_union == index <> encoded_record
+    end
+
+    test "errors with a clear error for tagged unions" do
+      record_json_factory = fn name ->
+        ~s"""
+          {
+            "type": "record",
+            "name": "#{name}",
+            "fields": [
+              {"type": "string", "name": "value"}
+            ]
+          }
+        """
+      end
+
+      json_schema = ~s([#{record_json_factory.("a")}, #{record_json_factory.("b")}])
+
+      {:ok, schema} = AvroEx.decode_schema(json_schema)
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message:
+                  "Schema Mismatch: Expected value of Union<possibilities=Record<name=a>|Record<name=b>>" <>
+                    ", got {\"c\", %{\"value\" => \"hello\"}}"
+              }} = @test_module.encode(schema, {"c", %{"value" => "hello"}})
     end
 
     test "errors if the data doesn't match the schema" do


### PR DESCRIPTION
This is mostly a small change, but I needed to add another parameter to `decode` / `do_decode`, which resulted in quite a lot of LOC changed. I'm not sure if this is the best way to bring the option to the code decoding unions though.