### PR TITLE
Allow empty strings as namespaces

### DIFF
--- a/lib/avro_ex/schema/parser.ex
+++ b/lib/avro_ex/schema/parser.ex
@@ -263,7 +263,10 @@ defmodule AvroEx.Schema.Parser do
 
   defp validate_namespace({_data, _rest, {_type, raw}} = input) do
     validate_field(input, :namespace, fn value ->
-      unless valid_full_name?(value) do
+      # From the specification: "A namespace is a dot-separated sequence of such
+      # names. The empty string may also be used as a namespace to indicate the
+      # null namespace.
+      unless valid_full_name?(value) or value == "" do
         error({:invalid_name, {:namespace, value}, raw})
       end
     end)

--- a/test/schema_parser_test.exs
+++ b/test/schema_parser_test.exs
@@ -100,7 +100,7 @@ defmodule AvroEx.Schema.ParserTest do
              }
     end
 
-    test "records can have fields that are logicalTypes" do
+    test "can have fields that are logicalTypes" do
       assert %Schema{schema: schema, context: context} =
                Parser.parse!(%{
                  "type" => "record",
@@ -198,6 +198,15 @@ defmodule AvroEx.Schema.ParserTest do
           ]
         })
       end
+    end
+
+    test "namespace is valid if it's empty" do
+      assert {:ok, _schema} = AvroEx.decode_schema(~S({
+        "type": "record",
+        "name": "something",
+        "namespace": "",
+        "fields" : [{"name": "count", "type": {"type": "string"}}]
+      }))
     end
   end
 


### PR DESCRIPTION
Fix #79 by allowing an empty string as a valid value for a namespace. 