### PR TITLE
Fix reference error formatting bug

### DIFF
--- a/lib/avro_ex/schema.ex
+++ b/lib/avro_ex/schema.ex
@@ -172,10 +172,6 @@ defmodule AvroEx.Schema do
     name
   end
 
-  def full_name(%Reference{type: name}, _parent_namespace) do
-    name
-  end
-
   def full_name(name, namespace) when is_binary(name) do
     cond do
       is_nil(namespace) ->
@@ -228,7 +224,7 @@ defmodule AvroEx.Schema do
   def type_name(%Array{items: type}), do: "Array<items=#{type_name(type)}>"
   def type_name(%Union{possibilities: types}), do: "Union<possibilities=#{Enum.map_join(types, "|", &type_name/1)}>"
   def type_name(%Record{} = record), do: "Record<name=#{full_name(record)}>"
-  def type_name(%Reference{} = record), do: "Reference<name=#{full_name(record)}>"
+  def type_name(%Reference{type: type}), do: "Reference<name=#{type}>"
   def type_name(%Record.Field{} = field), do: "Field<name=#{full_name(field)}>"
   def type_name(%Fixed{size: size} = fixed), do: "Fixed<name=#{full_name(fixed)}, size=#{size}>"
   def type_name(%AvroEnum{} = enum), do: "Enum<name=#{full_name(enum)}>"

--- a/lib/avro_ex/schema.ex
+++ b/lib/avro_ex/schema.ex
@@ -172,6 +172,10 @@ defmodule AvroEx.Schema do
     name
   end
 
+  def full_name(%Reference{type: name}, _parent_namespace) do
+    name
+  end
+
   def full_name(name, namespace) when is_binary(name) do
     cond do
       is_nil(namespace) ->
@@ -212,6 +216,9 @@ defmodule AvroEx.Schema do
 
       iex> type_name(%Record{name: "foo"})
       "Record<name=foo>"
+
+      iex> type_name(%Reference{type: "foo"})
+      "Reference<name=foo>"
   """
   @spec type_name(schema_types()) :: String.t()
   def type_name(%Primitive{type: :null}), do: "null"
@@ -221,6 +228,7 @@ defmodule AvroEx.Schema do
   def type_name(%Array{items: type}), do: "Array<items=#{type_name(type)}>"
   def type_name(%Union{possibilities: types}), do: "Union<possibilities=#{Enum.map_join(types, "|", &type_name/1)}>"
   def type_name(%Record{} = record), do: "Record<name=#{full_name(record)}>"
+  def type_name(%Reference{} = record), do: "Reference<name=#{full_name(record)}>"
   def type_name(%Record.Field{} = field), do: "Field<name=#{full_name(field)}>"
   def type_name(%Fixed{size: size} = fixed), do: "Fixed<name=#{full_name(fixed)}, size=#{size}>"
   def type_name(%AvroEnum{} = enum), do: "Enum<name=#{full_name(enum)}>"

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -162,7 +162,7 @@ defmodule AvroEx.Decode.Test do
 
     test "array with negative count" do
       {:ok, schema} = AvroEx.decode_schema(~S({"type": "array", "items": ["null", "int"]}))
-      {:ok, long_schema} = AvroEx.decode_schema("long")
+      {:ok, _long_schema} = AvroEx.decode_schema("long")
 
       {:ok, encoded_array} = AvroEx.encode(schema, [1, 2, 3, nil, 4, 5, nil], include_block_byte_size: true)
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -526,16 +526,29 @@ defmodule AvroEx.Encode.Test do
 
     test "(reference)" do
       assert schema =
-        AvroEx.decode_schema!(~S({"type": "record", "namespace": "beam.community", "name": "Name", "fields": [
-          {"name": "first_name", "type": {
-            "type": "record",
-            "name": "DefinedRecord",
-            "fields": [
-              {"type": "string", "name": "full"}
-            ]}
-          },
-          {"type": "beam.community.DefinedRecord", "name": "last_name"}
-        ]}))
+        AvroEx.decode_schema!(%{
+          "type" => "record",
+          "namespace" => "beam.community",
+          "name" => "Name",
+          "fields" => [
+            %{
+              "name" => "first_name",
+              "type" => %{
+                "type" => "record",
+                "name" => "DefinedRecord",
+                "fields" => [
+                  %{
+                    "type" => "string",
+                    "name" => "full"
+                  }
+                ]
+              }
+            },
+            %{
+              "type" => "beam.community.DefinedRecord",
+              "name" => "last_name"
+            }
+          ]})
 
       assert {:error,
               %AvroEx.EncodeError{
@@ -550,16 +563,29 @@ defmodule AvroEx.Encode.Test do
 
     test "(reference with union)" do
       assert schema =
-        AvroEx.decode_schema!(~S({"type": "record", "namespace": "beam.community", "name": "Name", "fields": [
-          {"name": "first_name", "type": {
-            "type": "record",
-            "name": "DefinedRecord",
-            "fields": [
-              {"type": "string", "name": "full"}
-            ]}
-          },
-          {"type": ["null", "beam.community.DefinedRecord"], "name": "last_name"}
-        ]}))
+        AvroEx.decode_schema!(%{
+          "type" => "record",
+          "namespace" => "beam.community",
+          "name" => "Name",
+          "fields" => [
+            %{
+              "name" => "first_name",
+              "type" => %{
+                "type" => "record",
+                "name" => "DefinedRecord",
+                "fields" => [
+                  %{
+                    "type" => "string",
+                    "name" => "full"
+                  }
+                ]
+              }
+            },
+            %{
+              "type" => ["null", "beam.community.DefinedRecord"],
+              "name" => "last_name"
+            }
+          ]})
 
       assert {:error,
               %AvroEx.EncodeError{

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -526,29 +526,30 @@ defmodule AvroEx.Encode.Test do
 
     test "(reference)" do
       assert schema =
-        AvroEx.decode_schema!(%{
-          "type" => "record",
-          "namespace" => "beam.community",
-          "name" => "Name",
-          "fields" => [
-            %{
-              "name" => "first_name",
-              "type" => %{
-                "type" => "record",
-                "name" => "DefinedRecord",
-                "fields" => [
-                  %{
-                    "type" => "string",
-                    "name" => "full"
-                  }
-                ]
-              }
-            },
-            %{
-              "type" => "beam.community.DefinedRecord",
-              "name" => "last_name"
-            }
-          ]})
+               AvroEx.decode_schema!(%{
+                 "type" => "record",
+                 "namespace" => "beam.community",
+                 "name" => "Name",
+                 "fields" => [
+                   %{
+                     "name" => "first_name",
+                     "type" => %{
+                       "type" => "record",
+                       "name" => "DefinedRecord",
+                       "fields" => [
+                         %{
+                           "type" => "string",
+                           "name" => "full"
+                         }
+                       ]
+                     }
+                   },
+                   %{
+                     "type" => "beam.community.DefinedRecord",
+                     "name" => "last_name"
+                   }
+                 ]
+               })
 
       assert {:error,
               %AvroEx.EncodeError{
@@ -563,33 +564,35 @@ defmodule AvroEx.Encode.Test do
 
     test "(reference with union)" do
       assert schema =
-        AvroEx.decode_schema!(%{
-          "type" => "record",
-          "namespace" => "beam.community",
-          "name" => "Name",
-          "fields" => [
-            %{
-              "name" => "first_name",
-              "type" => %{
-                "type" => "record",
-                "name" => "DefinedRecord",
-                "fields" => [
-                  %{
-                    "type" => "string",
-                    "name" => "full"
-                  }
-                ]
-              }
-            },
-            %{
-              "type" => ["null", "beam.community.DefinedRecord"],
-              "name" => "last_name"
-            }
-          ]})
+               AvroEx.decode_schema!(%{
+                 "type" => "record",
+                 "namespace" => "beam.community",
+                 "name" => "Name",
+                 "fields" => [
+                   %{
+                     "name" => "first_name",
+                     "type" => %{
+                       "type" => "record",
+                       "name" => "DefinedRecord",
+                       "fields" => [
+                         %{
+                           "type" => "string",
+                           "name" => "full"
+                         }
+                       ]
+                     }
+                   },
+                   %{
+                     "type" => ["null", "beam.community.DefinedRecord"],
+                     "name" => "last_name"
+                   }
+                 ]
+               })
 
       assert {:error,
               %AvroEx.EncodeError{
-                message: "Schema Mismatch: Expected value of Union<possibilities=null|Reference<name=beam.community.DefinedRecord>>, got :wat"
+                message:
+                  "Schema Mismatch: Expected value of Union<possibilities=null|Reference<name=beam.community.DefinedRecord>>, got :wat"
               }} = @test_module.encode(schema, %{first_name: %{full: "foo"}, last_name: :wat})
     end
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -524,6 +524,49 @@ defmodule AvroEx.Encode.Test do
               }} = @test_module.encode(schema, %{})
     end
 
+    test "(reference)" do
+      assert schema =
+        AvroEx.decode_schema!(~S({"type": "record", "namespace": "beam.community", "name": "Name", "fields": [
+          {"name": "first_name", "type": {
+            "type": "record",
+            "name": "DefinedRecord",
+            "fields": [
+              {"type": "string", "name": "full"}
+            ]}
+          },
+          {"type": "beam.community.DefinedRecord", "name": "last_name"}
+        ]}))
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Schema Mismatch: Expected value of Record<name=DefinedRecord>, got :wat"
+              }} = @test_module.encode(schema, %{first_name: %{full: "foo"}, last_name: :wat})
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Schema Mismatch: Expected value of Record<name=DefinedRecord>, got nil"
+              }} = @test_module.encode(schema, %{})
+    end
+
+    test "(reference with union)" do
+      assert schema =
+        AvroEx.decode_schema!(~S({"type": "record", "namespace": "beam.community", "name": "Name", "fields": [
+          {"name": "first_name", "type": {
+            "type": "record",
+            "name": "DefinedRecord",
+            "fields": [
+              {"type": "string", "name": "full"}
+            ]}
+          },
+          {"type": ["null", "beam.community.DefinedRecord"], "name": "last_name"}
+        ]}))
+
+      assert {:error,
+              %AvroEx.EncodeError{
+                message: "Schema Mismatch: Expected value of Union<possibilities=null|Reference<name=beam.community.DefinedRecord>>, got :wat"
+              }} = @test_module.encode(schema, %{first_name: %{full: "foo"}, last_name: :wat})
+    end
+
     test "(union)" do
       schema = AvroEx.decode_schema!(~S(["null", "string"]))
 

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -8,7 +8,7 @@ defmodule AvroEx.Schema.Test do
   alias AvroEx.Schema.Enum, as: AvroEnum
   alias AvroEx.Schema.Map, as: AvroMap
   alias AvroEx.Schema.Record.Field
-  alias AvroEx.Schema.{Array, Context, Fixed, Primitive, Record, Union}
+  alias AvroEx.Schema.{Array, Context, Fixed, Primitive, Record, Reference, Union}
 
   doctest AvroEx.Schema, import: true
 


### PR DESCRIPTION
When encoding invalid messages using avro_ex I encountered a `FunctionClauseError` exception. The exception looked like this (only the reference name differs from what I encountered in my application):

```
     ** (FunctionClauseError) no function clause matching in AvroEx.Schema.type_name/1

     The following arguments were given to AvroEx.Schema.type_name/1:
     
         # 1
         %AvroEx.Schema.Reference{type: "beam.community.DefinedRecord"}
```

To fix this I wrote tests for encoding of invalid union/reference data and added them to `AvroEx.Encode.Test`. Then I fixed the bug by adding the necessary clause to `AvroEx.Schema.type_name/1`.