### PR TITLE
Fix incorrect error for decimal encoding

### DIFF
--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -124,7 +124,7 @@ defmodule AvroEx.Encode do
 
         %struct{} when struct == Decimal ->
           if value.exp != -scale do
-            error("Incompatible decimal: expected scale #{-scale}, got #{value.exp}")
+            error({:incompatible_decimal, -scale, value.exp})
           end
 
           value.coef * value.sign

--- a/lib/avro_ex/encode_error.ex
+++ b/lib/avro_ex/encode_error.ex
@@ -32,4 +32,10 @@ defmodule AvroEx.EncodeError do
       message: "Invalid size for #{type}. Size of #{byte_size(binary)} for #{inspect(binary)}"
     }
   end
+
+  def new({:incompatible_decimal, expected_scale, actual_scale}) do
+    %__MODULE__{
+      message: "Incompatible decimal: expected scale #{expected_scale}, got #{actual_scale}"
+    }
+  end
 end

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -100,6 +100,21 @@ defmodule AvroEx.Encode.Test do
       assert encoded == File.read!("test/fixtures/decimal.avro")
     end
 
+    test "decimal encoding error" do
+      schema = "test/fixtures/decimal.avsc" |> File.read!() |> AvroEx.decode_schema!()
+
+      payload = %{
+        "decimalField1" => Decimal.new("1E-10"),
+        "decimalField2" => Decimal.new("0"),
+        "decimalField3" => Decimal.new("0"),
+        "decimalField4" => Decimal.new("0")
+      }
+
+      assert_raise(AvroEx.EncodeError, "Incompatible decimal: expected scale -15, got -10", fn ->
+        AvroEx.encode!(schema, payload)
+      end)
+    end
+
     test "decimal without using the Decimal library" do
       schema = "test/fixtures/decimal.avsc" |> File.read!() |> AvroEx.decode_schema!()
 


### PR DESCRIPTION
When handling errors in `AvroEx.Encode`, I made a mistake when calling `error/1`: it's supposed to be called with arguments supported by `AvroEx.DecodeError.new/1`.

This PR adds a test and fixes the mistake. 

