### PR TITLE
Fix String.slice deprecation warning in Elixir >= 1.16

### DIFF
--- a/lib/avro_ex/decode.ex
+++ b/lib/avro_ex/decode.ex
@@ -241,7 +241,7 @@ defmodule AvroEx.Decode do
           {[decoded_item | decoded_items], buffer}
         end)
 
-      {Enum.reverse(decoded_items), String.slice(rest, 1..-1)}
+      {Enum.reverse(decoded_items), String.slice(rest, 1..-1//1)}
     else
       {[], buffer}
     end
@@ -259,7 +259,7 @@ defmodule AvroEx.Decode do
           {[{decoded_key, decoded_value} | decoded_values], buffer}
         end)
 
-      {Map.new(decoded_values), String.slice(rest, 1..-1)}
+      {Map.new(decoded_values), String.slice(rest, 1..-1//1)}
     else
       {%{}, buffer}
     end


### PR DESCRIPTION
`String.slice(1..-1)` was [hard-deprecated in Elixir 1.16][changelog]. Fix the warning by giving `String.slice(term, 1..-1//1)`.

[changelog]: https://github.com/elixir-lang/elixir/releases/tag/v1.16.0