### PR TITLE
chore: setup common-config to template files

### DIFF
--- a/.github/workflows/common-config.yaml
+++ b/.github/workflows/common-config.yaml
@@ -1,0 +1,54 @@
+# This file is synced with beam-community/common-config. Any changes will be overwritten.
+
+name: Common Config
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/common-config.yaml
+  repository_dispatch:
+    types:
+      - common-config
+  schedule:
+    - cron: "8 12 8 * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: Common Config
+
+jobs:
+  Sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          persist-credentials: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Elixir
+        uses: stordco/actions-elixir/setup@v1
+        with:
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          elixir-version: "1.15"
+          otp-version: "26.0"
+
+      - name: Sync
+        uses: stordco/actions-sync@v1
+        with:
+          commit-message: "chore: sync files with beam-community/common-config"
+          pr-enabled: true
+          pr-labels: common-config
+          pr-title: "chore: sync files with beam-community/common-config"
+          pr-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          sync-auth: doomspork:${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          sync-branch: latest
+          sync-repository: github.com/beam-community/common-config.git


### PR DESCRIPTION
This adds a GitHub action workflow to enable common config syncing for the repository. More details available on the upstream repository [here](https://github.com/beam-community/common-config). In general:

- Templates files for automated / easier releasing of packages
- Common CI files for all workflows
- Common linting and formatting configuration (mix format, credo)
- Dependabot and stale issue workflow