### PR TITLE
[Proposal]: Add UUID conversion to and from 16 byte fixed sequences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
 
   dialyzer:
     name: Run Dialyzer for type checking
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set mix file hash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       HEX_API_KEY: ${{ secrets.HEXPM_SECRET }}
     steps:

--- a/lib/avro_ex.ex
+++ b/lib/avro_ex.ex
@@ -136,6 +136,14 @@ defmodule AvroEx do
   of blocks with their counts. This allows consumers of the encoded data to skip
   over those blocks in an efficient manner. Using the option `include_block_byte_size: true`
   enables adding those additional values.
+
+  ## UUID encoding
+
+  UUIDs can be decoded as strings using the canonical hex representation with 37 bytes.
+  Alternatively, encoding UUIDs in their 16 byte binary representation is much
+  more compact, saving 21 bytes per encoding.
+  See "UUIDs" on `decode/3` for how to convert binary representations back to
+  canonical strings during decoding.
   """
   @spec encode(Schema.t(), term, keyword()) ::
           {:ok, encoded_avro} | {:error, AvroEx.EncodeError.t() | Exception.t()}
@@ -184,6 +192,19 @@ defmodule AvroEx do
   into a Decimal struct with arbitrary precision.
 
   Otherwise, an approximate number is calculated.
+
+  ## UUIDs
+
+  When decoding a 16 byte fixed quantity with logical type "uuid", specify
+  `uuid_format: :binary` to retain the binary representation or
+  `uuid_format: :canonical_string` to convert to the canonical, hex as string representation.
+
+      iex> schema = AvroEx.decode_schema!(~S({"type": "fixed", "size": 16, "name": "fixed_uuid", "logicalType":"uuid"}))
+      iex> binary_uuid = <<85, 14, 132, 0, 226, 155, 65, 212, 167, 22, 68, 102, 85, 68, 0, 0>>
+      iex> AvroEx.decode(schema, binary_uuid, uuid_format: :binary)
+      {:ok, binary_uuid}
+      iex> AvroEx.decode(schema, binary_uuid, uuid_format: :canonical_string)
+      {:ok, "550e8400-e29b-41d4-a716-446655440000"}
 
   """
   @spec decode(Schema.t(), encoded_avro, keyword()) ::

--- a/lib/avro_ex/decode.ex
+++ b/lib/avro_ex/decode.ex
@@ -270,6 +270,25 @@ defmodule AvroEx.Decode do
     {:lists.nth(index + 1, symbols), rest}
   end
 
+  defp do_decode(%Fixed{size: size = 16, metadata: %{"logicalType" => "uuid"}}, %Context{}, data, opts)
+       when is_binary(data) do
+    <<fixed::binary-size(size), rest::binary>> = data
+
+    case Keyword.get(opts, :uuid_format, :binary) do
+      :binary ->
+        {fixed, rest}
+
+      :canonical_string ->
+        case Uniq.UUID.parse(fixed) do
+          {:ok, uuid} ->
+            {Uniq.UUID.to_string(uuid, :default), rest}
+
+          _ ->
+            error({:invalid_binary_uuid, fixed})
+        end
+    end
+  end
+
   defp do_decode(%Fixed{size: size}, %Context{}, data, _) when is_binary(data) do
     <<fixed::binary-size(size), rest::binary>> = data
     {fixed, rest}

--- a/lib/avro_ex/decode_error.ex
+++ b/lib/avro_ex/decode_error.ex
@@ -12,4 +12,9 @@ defmodule AvroEx.DecodeError do
     message = "Invalid UTF-8 string found #{inspect(str)}."
     %__MODULE__{message: message}
   end
+
+  def new({:invalid_binary_uuid, binary_uuid}) do
+    message = "Invalid binary UUID found #{inspect(binary_uuid)}."
+    %__MODULE__{message: message}
+  end
 end

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -169,6 +169,11 @@ defmodule AvroEx.Encode do
     bin
   end
 
+  defp do_encode(%Fixed{size: 16, metadata: %{"logicalType" => "uuid"}} = f, %Context{} = context, bin, opts)
+       when is_binary(bin) do
+    do_encode(f, context, Uniq.UUID.string_to_binary!(bin), opts)
+  end
+
   defp do_encode(%Fixed{} = fixed, %Context{} = context, bin, _) when is_binary(bin) do
     error({:incorrect_fixed_size, fixed, bin, context})
   end

--- a/lib/avro_ex/schema/fixed.ex
+++ b/lib/avro_ex/schema/fixed.ex
@@ -19,5 +19,10 @@ defmodule AvroEx.Schema.Fixed do
     true
   end
 
+  def match?(%__MODULE__{size: 16, metadata: %{"logicalType" => "uuid"}}, %Context{}, data)
+      when is_binary(data) do
+    Uniq.UUID.valid?(data)
+  end
+
   def match?(_fixed, _context, _data), do: false
 end

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,8 @@ defmodule AvroEx.Mixfile do
       {:dialyxir, "~> 1.1", only: :dev, runtime: false},
       {:ex_doc, "~> 0.20", only: :dev, runtime: false},
       {:stream_data, "~> 0.5", only: [:dev, :test]},
-      {:decimal, "~> 2.0", optional: true}
+      {:decimal, "~> 2.0", optional: true},
+      {:uniq, "~> 0.6"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -14,4 +14,5 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
   "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
+  "uniq": {:hex, :uniq, "0.6.1", "369660ecbc19051be526df3aa85dc393af5f61f45209bce2fa6d7adb051ae03c", [:mix], [{:ecto, "~> 3.0", [hex: :ecto, repo: "hexpm", optional: true]}], "hexpm", "6426c34d677054b3056947125b22e0daafd10367b85f349e24ac60f44effb916"},
 }


### PR DESCRIPTION
UUIDs are often passed around in application code in their canonical, hex as string representation e.g. "550e8400-e29b-41d4-a716-446655440000". Encoding UUIDs as Avro "string"s takes 37 bytes, while encoding UUIDs in their binary form fits into a 16 byte sized "fixed", saving 21 bytes per encoding.

This change allows application code to keep passing around canonical hex UUIDs while converting to the compact encoding, requiring only `uuid_format: :canonical_string` to be given in decode options.

The [Java reference implementation][java-implementation] also supports encoding UUIDs as both strings and 16 byte fixed sequences.

* Encoding is augmented such that a 16 byte fixed schema with `%{"logicalType" => "uuid"}`, converts a hex-string UUID to the 16 byte binary representation.

* Decoding is augmented such that given `uuid_format: :canonical_string` in decode options, the binary representation is converted to the canonical hex-string representation.

The encoding change is nearly backwards-compatible, previously when given an incorrectly size "fixed" with `{"logicalType": "uuid"}`, an error was raised, while now conversion is attempted.

The decoding change is fully backwards-compatible, as `uuid_format` defaults to `:binary`.

For UUID codec, the `uniq` library was added (no transitive dependencies).

[java-implementation]: https://github.com/apache/avro/blob/230414abbb68e63e68f3b55bfc0cbca94f2737f6/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java#L291-L309