### PR TITLE
fix: upgrade deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Elixir
         uses: erlef/setup-beam@v1.15
         with:
           elixir-version: "1.13.3" # Define the elixir version [required]
           otp-version: "24.2.1" # Define the OTP version [required]
       - name: Restore dependencies cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -37,15 +37,15 @@ jobs:
     name: Run Dialyzer for type checking
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set mix file hash
         id: set_vars
         run: |
           mix_hash="${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}"
-          echo "::set-output name=mix_hash::$mix_hash"
+          echo "mix_hash=$mix_hash" >> "$GITHUB_OUTPUT"
       - name: Cache PLT files
         id: cache-plt
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             _build/dev/*.plt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Elixir
-        uses: erlef/setup-beam@v1.15
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: "1.13.3" # Define the elixir version [required]
-          otp-version: "24.2.1" # Define the OTP version [required]
+          otp-version: "24.3" # Define the OTP version [required]
       - name: Restore dependencies cache
         uses: actions/cache@v4
         with:
@@ -54,9 +54,9 @@ jobs:
           restore-keys: |
             plt-cache-
       - name: Run Dialyzer
-        uses: erlef/setup-beam@v1.15
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: "1.13.3" # Define the elixir version [required]
-          otp-version: "24.2.1" # Define the OTP version [required]
+          otp-version: "24.3" # Define the OTP version [required]
       - run: mix deps.get
       - run: mix dialyzer

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,10 @@ jobs:
       HEX_API_KEY: ${{ secrets.HEXPM_SECRET }}
     steps:
       - uses: actions/checkout@v4
-      - uses: erlef/setup-beam@v1.15
+      - uses: erlef/setup-beam@v1
         with:
           elixir-version: '1.13.3'
-          otp-version: '24.2.1'
+          otp-version: '24.3'
       - run: mix deps.get
       - run: mix compile --docs
       - run: mix hex.publish --yes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       HEX_API_KEY: ${{ secrets.HEXPM_SECRET }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1.15
         with:
           elixir-version: '1.13.3'


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout` from v2 to v4 in `ci.yml` and `deploy.yml`
- Upgrades `actions/cache` from v2 to v4 in `ci.yml`
- Replaces deprecated `::set-output` syntax with `$GITHUB_OUTPUT` in the dialyzer job

GitHub has sunset `actions/cache` v1/v2 and `actions/checkout` v2, causing both CI jobs (`Build and test` and `Run Dialyzer for type checking`) to fail immediately during job setup with:

> This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`.

See: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/

## Test plan
- [ ] Verify CI passes on this PR (both `Build and test` and `Run Dialyzer for type checking` jobs)