### PR TITLE
fix: decode maps with blocked (negative-count) framing

### DIFF
--- a/lib/avro_ex/decode.ex
+++ b/lib/avro_ex/decode.ex
@@ -248,7 +248,13 @@ defmodule AvroEx.Decode do
   end
 
   defp do_decode(%AvroEx.Schema.Map{values: value_schema}, %Context{} = context, data, opts) when is_binary(data) do
-    {count, buffer} = do_decode(%Primitive{type: :long}, context, data, opts)
+    {count, buffer} =
+      with {count, rest} when count < 0 <-
+             do_decode(%Primitive{type: :long}, context, data, opts) do
+        {_byte_size, buffer} = do_decode(%Primitive{type: :long}, context, rest, opts)
+        {abs(count), buffer}
+      end
+
     string_schema = %Primitive{type: :string}
 
     if count > 0 do

--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -216,17 +216,24 @@ defmodule AvroEx.Encode do
         <<0>>
 
       size ->
-        acc = do_encode(%Primitive{type: :long}, context, size, opts)
-
-        encoded_map =
-          Enum.reduce(map, acc, fn {k, v}, acc ->
+        map_payload =
+          Enum.reduce(map, <<>>, fn {k, v}, acc ->
             key = do_encode(%Primitive{type: :string}, context, k, opts)
             value = do_encode(values, context, v, opts)
 
             acc <> key <> value
           end)
 
-        encoded_map <> <<0>>
+        header =
+          if Keyword.get(opts, :include_block_byte_size, false) do
+            negated_count = do_encode(%Primitive{type: :long}, context, -1 * size, opts)
+            byte_size = do_encode(%Primitive{type: :long}, context, byte_size(map_payload), opts)
+            negated_count <> byte_size
+          else
+            do_encode(%Primitive{type: :long}, context, size, opts)
+          end
+
+        header <> map_payload <> <<0>>
     end
   end
 

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -193,6 +193,15 @@ defmodule AvroEx.Decode.Test do
       assert {:ok, %{"a" => 1, "b" => nil, "c" => 3}} = AvroEx.decode(schema, encoded_array)
     end
 
+    test "map with negative count" do
+      {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": ["null", "int"]}))
+
+      {:ok, encoded_map} =
+        AvroEx.encode(schema, %{"a" => 1, "b" => nil, "c" => 3}, include_block_byte_size: true)
+
+      assert {:ok, %{"a" => 1, "b" => nil, "c" => 3}} = AvroEx.decode(schema, encoded_map)
+    end
+
     test "empty map" do
       {:ok, schema} = AvroEx.decode_schema(~S({"type": "map", "values": ["null", "int"]}))
 


### PR DESCRIPTION
Per the Avro spec, maps may be encoded as one or more blocks. Each block starts with a long: a positive count means "this many key/value pairs follow", while a negative count means "abs(count) pairs follow, preceded by a long byte size for the block".

The Map decoder only handled the positive-count form: a negative count fell through to the empty-map branch, returning %{} and leaving the block byte size in the buffer. The Array decoder already handled both forms correctly; this change mirrors that logic in the Map decoder.

While here, teach the Map encoder to honor :include_block_byte_size for symmetry with the Array encoder, which enables round-tripping the blocked form and makes the new regression test possible.

Discovered while consuming a Confluent topic produced by hamba/avro (Go), which emits non-empty maps using the blocked form.