### PR TITLE
fix: replace stordco/actions-sync with beam-community/actions-sync

### DIFF
--- a/.github/common-config.yaml
+++ b/.github/common-config.yaml
@@ -1,0 +1,2 @@
+ignore-files:
+  - .github/common-config.yaml # Ignore this file itself

--- a/.github/workflows/common-config.yaml
+++ b/.github/workflows/common-config.yaml
@@ -42,7 +42,7 @@ jobs:
           otp-version: "26.0"
 
       - name: Sync
-        uses: stordco/actions-sync@v1
+        uses: beam-community/actions-sync@v1
         with:
           commit-message: "chore: sync files with beam-community/common-config"
           pr-enabled: true
@@ -50,5 +50,6 @@ jobs:
           pr-title: "chore: sync files with beam-community/common-config"
           pr-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           sync-auth: doomspork:${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          sync-branch: latest
+          sync-tree: latest
           sync-repository: github.com/beam-community/common-config.git
+          config-file: .github/common-config.yaml


### PR DESCRIPTION
## Summary

The Common Config sync workflow has been broken since the `stordco` org transferred its actions to `beam-community` — GitHub Actions does not resolve cross-org redirects, so the runner fails fast at "Prepare all required actions" with `Unable to resolve action stordco/actions-sync, not found`.

This mirrors the fix already applied to [beam-community/ex_machina#530](https://github.com/beam-community/ex_machina/pull/530):

- `stordco/actions-sync@v1` → `beam-community/actions-sync@v1`
- `sync-branch: latest` → `sync-tree: latest` (input was renamed in the fork; `sync-branch` is deprecated)
- Added `config-file: .github/common-config.yaml` (now a supported input)
- New `.github/common-config.yaml` with a single `ignore-files` entry that excludes itself, so a future template sync won't clobber per-repo overrides

The intent is to restore the monthly sync; downstream template drift (newer `actions/checkout`, `actions/setup-node`, Elixir/OTP bumps) will land naturally on the next successful run rather than being hand-rolled here.

## Complexity Notes

- `.github/workflows/common-config.yaml` is normally managed by the sync action itself and carries a "Any changes will be overwritten" header. We have to edit it manually once to bootstrap the fix, because the workflow that would overwrite it IS the broken one.
- This repo's previous `stordco/actions-elixir/setup` reference was already replaced with `erlef/setup-beam` in 88caf65, so after this PR there should be zero `stordco` references in `.github/`.

## Test Steps

1. After merge, navigate to **Actions → Common Config** in the GitHub UI.
2. Trigger the workflow via **Run workflow** (`workflow_dispatch`).
3. Confirm the run reaches the **Sync** step without the "Unable to resolve action" error.
4. Verify the action either opens a sync PR or reports no changes — both indicate success.
5. As a sanity check: `grep -r stordco .github` should return no matches.

## Checklist

- [ ] Tests added/updated *(N/A — workflow-only change)*
- [ ] Documentation updated (if applicable) *(N/A)*