### PR TITLE
fix: preserve an explicit "default": null through schema re-encode

### DIFF
--- a/lib/avro_ex/encode.ex
+++ b/lib/avro_ex/encode.ex
@@ -181,7 +181,11 @@ defmodule AvroEx.Encode do
   end
 
   defp do_encode(%Field{type: type, default: default}, %Context{} = context, nil, opts) do
-    do_encode(type, context, default, opts)
+    # A field with no default at all carries the Field.no_default/0 sentinel,
+    # not `nil` -- fall back to encoding `nil` itself (the pre-existing
+    # behavior) rather than encoding the sentinel as if it were real data.
+    value = if default == Field.no_default(), do: nil, else: default
+    do_encode(type, context, value, opts)
   end
 
   defp do_encode(%Field{type: type}, %Context{} = context, value, opts) do

--- a/lib/avro_ex/schema/encoder.ex
+++ b/lib/avro_ex/schema/encoder.ex
@@ -41,7 +41,7 @@ defmodule AvroEx.Schema.Encoder do
     config = update_in(config.namespace, &Schema.namespace(struct, &1))
 
     pairs =
-      for {k, v} <- extract(struct), not empty?(v), keep?(k, config) do
+      for {k, v} <- extract(struct), keep_value?(struct_type, k, v), keep?(k, config) do
         case k do
           k when k in [:values, :items, :type] -> {k, do_encode(v, config)}
           :fields -> {k, Enum.map(v, &do_encode(&1, config))}
@@ -87,6 +87,14 @@ defmodule AvroEx.Schema.Encoder do
   defp empty?(""), do: true
   defp empty?(map) when map == %{}, do: true
   defp empty?(_), do: false
+
+  # Record.Field's `:default` must survive re-encoding even when its value is
+  # `nil` -- that's the Avro null literal, a real declared default, distinct
+  # from "no default" (Record.Field.no_default/0). Every other key on every
+  # struct type, including Array/AvroMap's own unrelated `:default` field,
+  # keeps the original emptiness-based filtering unchanged.
+  defp keep_value?(Field, :default, v), do: v != Field.no_default()
+  defp keep_value?(_struct_type, _k, v), do: not empty?(v)
 
   defp keep?(k, %{canonical?: true}) do
     k in ~w(type name fields symbols items values size)a

--- a/lib/avro_ex/schema/parser.ex
+++ b/lib/avro_ex/schema/parser.ex
@@ -189,8 +189,17 @@ defmodule AvroEx.Schema.Parser do
     info = {type, data}
 
     Enum.reduce(keys, {%{}, data, info}, fn key, {data, rest, info} ->
-      case Map.pop(rest, to_string(key)) do
-        {nil, rest} ->
+      case Map.pop(rest, to_string(key), :__avro_ex_key_missing__) do
+        {:__avro_ex_key_missing__, rest} ->
+          {data, rest, info}
+
+        # Every key except `:default` keeps treating an explicit JSON `null`
+        # the same as the key being absent -- unchanged from before. `:default`
+        # must not: the Avro null literal decodes to `nil`, and collapsing
+        # "no default" with "default is null" here is exactly what made the
+        # encoder unable to round-trip an explicit `"default": null` (see
+        # Record.Field.no_default/0).
+        {nil, rest} when key != :default ->
           {data, rest, info}
 
         {value, rest} ->
@@ -250,6 +259,26 @@ defmodule AvroEx.Schema.Parser do
       # null namespace.
       valid_full_name?(value) or value == "" or error({:invalid_name, {:namespace, value}, raw})
     end)
+  end
+
+  # Record.Field distinguishes "no default" (the Record.Field.no_default/0
+  # sentinel) from "default is the Avro null literal" (`nil`), but validation
+  # leniency here is unchanged from before this fix: an explicit `nil`
+  # default is left unvalidated against the field's type, same as "no
+  # default" always was. (Actually validating an explicit `nil` default is a
+  # separate, breaking change -- this repo's own fixtures rely on the old
+  # leniency for `"default": null` on non-nullable fields.)
+  defp validate_default(%Record.Field{default: default} = schema)
+       when default == :__avro_ex_no_default__ or is_nil(default),
+       do: schema
+
+  defp validate_default(%Record.Field{default: default} = schema) do
+    case AvroEx.encode(%Schema{schema: schema, context: %Context{}}, default) do
+      {:ok, _data} -> :ok
+      {:error, reason} -> error({:invalid_default, schema, reason})
+    end
+
+    schema
   end
 
   defp validate_default(%{default: nil} = schema), do: schema

--- a/lib/avro_ex/schema/record/field.ex
+++ b/lib/avro_ex/schema/record/field.ex
@@ -4,14 +4,37 @@ defmodule AvroEx.Schema.Record.Field do
   alias AvroEx.Schema
   alias AvroEx.Schema.Context
 
+  # A field's `default` is a legitimate Avro value, and Avro's null literal
+  # decodes to Elixir's `nil` -- so a field with no default at all is
+  # indistinguishable from one whose default is explicitly `null` if `nil`
+  # is also used as the "absent" marker. This sentinel breaks that tie: it
+  # is the struct's actual default value for `:default`, so `nil` stays free
+  # to mean "the default is the Avro null literal".
+  @typedoc false
+  @type no_default :: :__avro_ex_no_default__
+
+  @no_default :__avro_ex_no_default__
+
   typedstruct do
     field(:name, String.t(), enforce: true)
     field(:doc, String.t())
     field(:type, Schema.schema_types(), enforce: true)
-    field(:default, Schema.schema_types())
+    field(:default, Schema.schema_types() | no_default(), default: @no_default)
     field(:aliases, [Schema.alias()], default: [])
     field(:metadata, Schema.metadata(), default: %{})
   end
+
+  @doc false
+  @spec no_default() :: no_default()
+  def no_default, do: @no_default
+
+  @doc """
+  Returns `true` if `field` declares a default value (including an explicit
+  `null` default), `false` if it declares none.
+  """
+  @spec has_default?(t()) :: boolean()
+  def has_default?(%__MODULE__{default: @no_default}), do: false
+  def has_default?(%__MODULE__{}), do: true
 
   @spec match?(AvroEx.Schema.Record.Field.t(), AvroEx.Schema.Context.t(), any()) :: boolean()
   def match?(%__MODULE__{type: type}, %Context{} = context, data) do

--- a/test/schema_encoder_test.exs
+++ b/test/schema_encoder_test.exs
@@ -99,6 +99,31 @@ defmodule AvroEx.Schema.EncoderTest do
                "{\"aliases\":[\"a_map\"],\"doc\":\"docs!\",\"fields\":[{\"aliases\":[\"first\"],\"default\":1,\"doc\":\"field\",\"name\":\"one\",\"type\":{\"type\":\"int\"},\"meta\":\"meta\"}],\"name\":\"all\",\"namespace\":\"beam.community\",\"type\":\"record\",\"extra\":\"val\"}"
     end
 
+    test "preserves an explicit null default on a nullable field" do
+      input = %{
+        "type" => "record",
+        "name" => "test",
+        "fields" => [%{"name" => "a", "type" => ["null", "string"], "default" => nil}]
+      }
+
+      assert schema = AvroEx.decode_schema!(input)
+
+      assert AvroEx.encode_schema(schema) ==
+               ~S({"fields":[{"default":null,"name":"a","type":[{"type":"null"},{"type":"string"}]}],"name":"test","type":"record"})
+    end
+
+    test "omits default entirely when the field declares none" do
+      input = %{
+        "type" => "record",
+        "name" => "test",
+        "fields" => [%{"name" => "a", "type" => "string"}]
+      }
+
+      assert schema = AvroEx.decode_schema!(input)
+
+      refute AvroEx.encode_schema(schema) =~ "default"
+    end
+
     test "array" do
       # primitive array
       input = %{"type" => "array", "items" => "int"}

--- a/test/schema_parser_test.exs
+++ b/test/schema_parser_test.exs
@@ -140,6 +140,42 @@ defmodule AvroEx.Schema.ParserTest do
       end
     end
 
+    test "a field's explicit null default is preserved and distinct from having no default" do
+      %Schema{schema: schema} =
+        Parser.parse!(%{
+          "type" => "record",
+          "name" => "kyc",
+          "fields" => [
+            %{"name" => "nickname", "type" => ["null", "string"], "default" => nil},
+            %{"name" => "surname", "type" => "string"}
+          ]
+        })
+
+      assert %Record{fields: [with_null_default, without_default]} = schema
+
+      assert with_null_default.default == nil
+      assert Record.Field.has_default?(with_null_default)
+
+      assert without_default.default == Record.Field.no_default()
+      refute Record.Field.has_default?(without_default)
+    end
+
+    test "an explicit null default is not validated against the field's type, same as before" do
+      # Matches the pre-existing leniency for "no default": neither is checked
+      # against the field's type. Tightening this is a separate, breaking
+      # change this fix intentionally does not make.
+      assert %Schema{schema: %Record{fields: [field]}} =
+               Parser.parse!(%{
+                 "type" => "record",
+                 "name" => "lenient_null_default",
+                 "fields" => [
+                   %{"name" => "key", "type" => "long", "default" => nil}
+                 ]
+               })
+
+      assert field.default == nil
+    end
+
     test "creating a record without a name will raise" do
       message =
         "Schema missing required key `name` for AvroEx.Schema.Record in %{\"fields\" => [%{\"name\" => \"key\", \"type\" => \"long\"}], \"type\" => \"record\"}"


### PR DESCRIPTION
## Summary

`AvroEx.Schema.Record.Field`'s `:default` has no struct default of its own, so it falls back to `nil` — the same value Avro's `null` literal decodes to. A field with no default at all and a field whose default is explicitly `null` are therefore indistinguishable once parsed, and `Schema.Encoder`'s `empty?/1` filter (which treats `nil` as "absent") silently drops `"default":null` on re-encode.

This surfaced downstream: re-encoding a parsed schema before registering it with a Confluent Schema Registry silently dropped `"default":null` on nullable fields, breaking BACKWARD-compatible schema evolution (the registry rejects the new field as having no default, even though the source schema declared one).

**Fix:** `Field` now carries a dedicated `Field.no_default/0` sentinel as its actual struct default, so `nil` is free to mean only "the default is `null`":

- `parser.ex`'s `cast/3` now lets an explicit JSON `null` through for the `:default` key specifically — every other key is unchanged (`nil` there still collapses with "absent", exactly as before).
- `encoder.ex` keeps a field's `:default` even when it's `nil`, as long as it isn't the `no_default` sentinel; every other key/struct (including `Array`/`AvroMap`'s own unrelated `:default` field) is filtered exactly as before.
- `encode.ex`'s data-encoding path (substituting a field's default for a missing/`nil` value in an actual record) now maps the sentinel back to `nil` before encoding, so it never tries to encode the sentinel atom as real data.

`validate_default`'s leniency toward `nil` defaults is **intentionally left unchanged** — this repo's own existing fixtures (`test/schema_test.exs`, `test/avro_ex_test.exs`) rely on `"default": null` being accepted on non-nullable fields without validation. I initially tightened this to also validate explicit `null` defaults against the field's type, but that broke 44 existing tests, so I backed it out to keep this PR a pure bugfix with no behavior change beyond the round-trip preservation itself.

## Test plan

Verified in an `elixir:1.19-otp-27` container:
- [x] `mix test` — `26 doctests, 259 tests, 0 failures` (one pre-existing `property_test.exs` timeout excluded — reproduced identically against unmodified `main`, unrelated to this change).
- [x] `mix format --check-formatted` — clean.
- [x] `mix credo --strict` — no issues.
- [x] `mix dialyzer` — 0 errors.
- [x] Added regression tests: `test/schema_encoder_test.exs` (round-trip preserves `"default":null`; a field with no default is still omitted entirely) and `test/schema_parser_test.exs` (`Field.has_default?/1` distinguishes the two cases; explicit `null` defaults remain unvalidated, matching prior leniency).